### PR TITLE
Use operation response schema to make better mock assertions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,4 @@ node_modules
 # Swagger Testing (swagger-test-template)
 ################################################################################
 .idea
+test/instagram

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "js-yaml": "^3.3.1",
     "mocha": "^2.2.5",
     "mocha-eslint": "^0.1.7",
-    "walk": "^2.3.9"
+    "walk": "^2.3.9",
+    "z-schema": "^3.12.0"
   },
   "dependencies": {
     "handlebars": "^3.0.3"

--- a/templates/outerDescribe.handlebars
+++ b/templates/outerDescribe.handlebars
@@ -1,5 +1,9 @@
 'use strict';
 var chai = require('chai');
+{{#unless noResponseDefinitions}}
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+{{/unless}}
 {{#is assertion 'expect'}}
 var expect = chai.expect;
 {{/is}}

--- a/templates/request/get/get.handlebars
+++ b/templates/request/get/get.handlebars
@@ -1,4 +1,11 @@
   it('should respond with {{description}}', function(done) {
+      {{#unless noSchema}}
+      /*eslint-disable*/
+      {{> schema-partial this}}
+
+      /*eslint-enable*/
+      {{/unless}}
+
       request({
         url: '{{path}}',
         method: 'GET',
@@ -10,15 +17,30 @@
           return;
         }
 
-        {{#is assertion 'expect'}}
-        expect(body).to.have.property('name');
-        {{/is}}
-        {{#is assertion 'should'}}
-        body.should.have.property('name');
-        {{/is}}
-        {{#is assertion 'assert'}}
-        assert.property(body, 'name');
-        {{/is}}
+        {{#if noSchema}}
+            {{#is ../assertion 'expect'}}
+        expect(body).to.equal(null);
+            {{/is}}
+            {{#is ../assertion 'should'}}
+        body.should.equal(null);
+            {{/is}}
+            {{#is ../assertion 'assert'}}
+        assert.isNull(body);
+            {{/is}}
+        {{/if}}
+        {{#unless noSchema}}
+            {{#is ../assertion 'expect'}}
+        expect(validator.validate(body, schema)).to.be.true;
+
+            {{/is}}
+            {{#is ../assertion 'should'}}
+        validator.validate(body, schema).should.be.true;
+
+            {{/is}}
+            {{#is ../assertion 'assert'}}
+        assert.true(validator.validate(body, schema));
+            {{/is}}
+        {{/unless}}
         done();
       });
     });

--- a/templates/request/post/post.handlebars
+++ b/templates/request/post/post.handlebars
@@ -1,4 +1,11 @@
   it('should respond with {{description}}', function(done) {
+      {{#unless noSchema}}
+      /*eslint-disable*/
+      {{> schema-partial this}}
+
+      /*eslint-enable*/
+      {{/unless}}
+
       request({
         url: '{{path}}',
         method: 'POST',
@@ -15,15 +22,30 @@
           return;
         }
 
-        {{#is assertion 'expect'}}
-        expect(body).to.have.property('name');
-        {{/is}}
-        {{#is assertion 'should'}}
-        body.should.have.property('name');
-        {{/is}}
-        {{#is assertion 'assert'}}
-        assert.property(body, 'name');
-        {{/is}}
+        {{#if noSchema}}
+            {{#is ../assertion 'expect'}}
+        expect(body).to.equal(null);
+            {{/is}}
+            {{#is ../assertion 'should'}}
+        body.should.equal(null);
+            {{/is}}
+            {{#is ../assertion 'assert'}}
+        assert.isNull(body);
+            {{/is}}
+        {{/if}}
+        {{#unless noSchema}}
+            {{#is ../assertion 'expect'}}
+        expect(validator.validate(body, schema)).to.be.true;
+
+            {{/is}}
+            {{#is ../assertion 'should'}}
+        validator.validate(body, schema).should.be.true;
+
+            {{/is}}
+            {{#is ../assertion 'assert'}}
+        assert.true(validator.validate(body, schema));
+            {{/is}}
+        {{/unless}}
         done();
       });
     });

--- a/templates/request/put/put.handlebars
+++ b/templates/request/put/put.handlebars
@@ -1,4 +1,11 @@
   it('should respond with {{description}}', function(done) {
+      {{#unless noSchema}}
+      /*eslint-disable*/
+      {{> schema-partial this}}
+
+      /*eslint-enable*/
+      {{/unless}}
+
       request({
         url: '{{path}}',
         method: 'PUT',
@@ -15,15 +22,30 @@
           return;
         }
 
-        {{#is assertion 'expect'}}
-        expect(body).to.have.property('name');
-        {{/is}}
-        {{#is assertion 'should'}}
-        body.should.have.property('name');
-        {{/is}}
-        {{#is assertion 'assert'}}
-        assert.property(body, 'name');
-        {{/is}}
+        {{#if noSchema}}
+            {{#is ../assertion 'expect'}}
+        expect(body).to.equal(null);
+            {{/is}}
+            {{#is ../assertion 'should'}}
+        body.should.equal(null);
+            {{/is}}
+            {{#is ../assertion 'assert'}}
+        assert.isNull(body);
+            {{/is}}
+        {{/if}}
+        {{#unless noSchema}}
+            {{#is ../assertion 'expect'}}
+        expect(validator.validate(body, schema)).to.be.true;
+
+            {{/is}}
+            {{#is ../assertion 'should'}}
+        validator.validate(body, schema).should.be.true;
+
+            {{/is}}
+            {{#is ../assertion 'assert'}}
+        assert.true(validator.validate(body, schema));
+            {{/is}}
+        {{/unless}}
         done();
       });
     });

--- a/templates/schema.handlebars
+++ b/templates/schema.handlebars
@@ -1,0 +1,1 @@
+var schema = {{schema}};

--- a/templates/supertest/get/get.handlebars
+++ b/templates/supertest/get/get.handlebars
@@ -1,4 +1,11 @@
   it('should respond with {{description}}', function(done) {
+      {{#unless noSchema}}
+      /*eslint-disable*/
+      {{> schema-partial this}}
+
+      /*eslint-enable*/
+      {{/unless}}
+
       api.get('{{path}}')
       .set('Accept', 'application/json')
       .expect({{responseCode}})
@@ -8,15 +15,30 @@
           return;
         }
 
-        {{#is assertion 'expect'}}
-        expect(res).to.have.property('name');
-        {{/is}}
-        {{#is assertion 'should'}}
-        res.should.have.property('name');
-        {{/is}}
-        {{#is assertion 'assert'}}
-        assert.property(res, 'name');
-        {{/is}}
+        {{#if noSchema}}
+            {{#is ../assertion 'expect'}}
+        expect(res).to.equal(null);
+            {{/is}}
+            {{#is ../assertion 'should'}}
+        res.should.equal(null);
+            {{/is}}
+            {{#is ../assertion 'assert'}}
+        assert.isNull(res);
+            {{/is}}
+        {{/if}}
+        {{#unless noSchema}}
+            {{#is ../assertion 'expect'}}
+        expect(validator.validate(res, schema)).to.be.true;
+
+            {{/is}}
+            {{#is ../assertion 'should'}}
+        validator.validate(res, schema).should.be.true;
+
+            {{/is}}
+            {{#is ../assertion 'assert'}}
+        assert.true(validator.validate(res, schema));
+            {{/is}}
+        {{/unless}}
         done();
       });
     });

--- a/templates/supertest/post/post.handlebars
+++ b/templates/supertest/post/post.handlebars
@@ -1,4 +1,11 @@
   it('should respond with {{description}}', function(done) {
+      {{#unless noSchema}}
+      /*eslint-disable*/
+      {{> schema-partial this}}
+
+      /*eslint-enable*/
+      {{/unless}}
+
       api.post('{{path}}')
       .set('Accept', 'application/json')
       .send({
@@ -13,15 +20,30 @@
           return;
         }
 
-        {{#is assertion 'expect'}}
-        expect(res).to.have.property('name');
-        {{/is}}
-        {{#is assertion 'should'}}
-        res.should.have.property('name');
-        {{/is}}
-        {{#is assertion 'assert'}}
-        assert.property(res, 'name');
-        {{/is}}
+        {{#if noSchema}}
+            {{#is ../assertion 'expect'}}
+        expect(res).to.equal(null);
+            {{/is}}
+            {{#is ../assertion 'should'}}
+        res.should.equal(null);
+            {{/is}}
+            {{#is ../assertion 'assert'}}
+        assert.isNull(res);
+            {{/is}}
+        {{/if}}
+        {{#unless noSchema}}
+            {{#is ../assertion 'expect'}}
+        expect(validator.validate(res, schema)).to.be.true;
+
+            {{/is}}
+            {{#is ../assertion 'should'}}
+        validator.validate(res, schema).should.be.true;
+
+            {{/is}}
+            {{#is ../assertion 'assert'}}
+        assert.true(validator.validate(res, schema));
+            {{/is}}
+        {{/unless}}
         done();
       });
     });

--- a/templates/supertest/put/put.handlebars
+++ b/templates/supertest/put/put.handlebars
@@ -1,4 +1,11 @@
   it('should respond with {{description}}', function(done) {
+      {{#unless noSchema}}
+      /*eslint-disable*/
+      {{> schema-partial this}}
+
+      /*eslint-enable*/
+      {{/unless}}
+
       api.put('{{path}}')
       .set('Accept', 'application/json')
       .send({
@@ -13,15 +20,30 @@
           return;
         }
 
-        {{#is assertion 'expect'}}
-        expect(res).to.have.property('name');
-        {{/is}}
-        {{#is assertion 'should'}}
-        res.should.have.property('name');
-        {{/is}}
-        {{#is assertion 'assert'}}
-        assert.property(res, 'name');
-        {{/is}}
+        {{#if noSchema}}
+            {{#is ../assertion 'expect'}}
+        expect(res).to.equal(null);
+            {{/is}}
+            {{#is ../assertion 'should'}}
+        res.should.equal(null);
+            {{/is}}
+            {{#is ../assertion 'assert'}}
+        assert.isNull(res);
+            {{/is}}
+        {{/if}}
+        {{#unless noSchema}}
+            {{#is ../assertion 'expect'}}
+        expect(validator.validate(res, schema)).to.be.true;
+
+            {{/is}}
+            {{#is ../assertion 'should'}}
+        validator.validate(res, schema).should.be.true;
+
+            {{/is}}
+            {{#is ../assertion 'assert'}}
+        assert.true(validator.validate(res, schema));
+            {{/is}}
+        {{/unless}}
         done();
       });
     });

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -2,3 +2,5 @@
   extends: ../.eslintrc
   env:
     mocha: true
+  rules:
+    no-unused-expressions: false

--- a/test/minimal/compare/output1__Stub.js
+++ b/test/minimal/compare/output1__Stub.js
@@ -7,6 +7,7 @@ var request = require('request');
 describe('/', function() {
   describe('get', function() {
     it('should respond with 200 OK', function(done) {
+
       request({
         url: 'http://localhost:10010/',
         method: 'GET',
@@ -18,7 +19,7 @@ describe('/', function() {
           return;
         }
 
-        body.should.have.property('name');
+        body.should.equal(null);
         done();
       });
     });

--- a/test/minimal/compare/output2__Stub.js
+++ b/test/minimal/compare/output2__Stub.js
@@ -7,6 +7,7 @@ var request = require('request');
 describe('/', function() {
   describe('get', function() {
     it('should respond with 200 OK', function(done) {
+
       request({
         url: 'http://localhost:10010/',
         method: 'GET',
@@ -18,7 +19,7 @@ describe('/', function() {
           return;
         }
 
-        body.should.have.property('name');
+        body.should.equal(null);
         done();
       });
     });

--- a/test/minimal/compare/output3__Stub.js
+++ b/test/minimal/compare/output3__Stub.js
@@ -8,6 +8,7 @@ var api = supertest('http://localhost:10010'); // supertest init;
 describe('/', function() {
   describe('get', function() {
     it('should respond with 200 OK', function(done) {
+
       api.get('/')
       .set('Accept', 'application/json')
       .expect(200)
@@ -17,7 +18,7 @@ describe('/', function() {
           return;
         }
 
-        res.should.have.property('name');
+        res.should.equal(null);
         done();
       });
     });

--- a/test/minimal/compare/output4__Stub.js
+++ b/test/minimal/compare/output4__Stub.js
@@ -8,6 +8,7 @@ var api = supertest('http://localhost:10010'); // supertest init;
 describe('/', function() {
   describe('get', function() {
     it('should respond with 200 OK', function(done) {
+
       api.get('/')
       .set('Accept', 'application/json')
       .expect(200)
@@ -17,7 +18,7 @@ describe('/', function() {
           return;
         }
 
-        res.should.have.property('name');
+        res.should.equal(null);
         done();
       });
     });

--- a/test/minimal/compare/output5__Stub.js
+++ b/test/minimal/compare/output5__Stub.js
@@ -6,6 +6,7 @@ var request = require('request');
 describe('/', function() {
   describe('get', function() {
     it('should respond with 200 OK', function(done) {
+
       request({
         url: 'http://localhost:10010/',
         method: 'GET',
@@ -17,7 +18,7 @@ describe('/', function() {
           return;
         }
 
-        assert.property(body, 'name');
+        assert.isNull(body);
         done();
       });
     });

--- a/test/minimal/compare/output6__Stub.js
+++ b/test/minimal/compare/output6__Stub.js
@@ -6,6 +6,7 @@ var request = require('request');
 describe('/', function() {
   describe('get', function() {
     it('should respond with 200 OK', function(done) {
+
       request({
         url: 'http://localhost:10010/',
         method: 'GET',
@@ -17,7 +18,7 @@ describe('/', function() {
           return;
         }
 
-        expect(body).to.have.property('name');
+        expect(body).to.equal(null);
         done();
       });
     });

--- a/test/minimal/compare/output7__Stub.js
+++ b/test/minimal/compare/output7__Stub.js
@@ -7,6 +7,7 @@ var api = supertest('http://localhost:10010'); // supertest init;
 describe('/', function() {
   describe('get', function() {
     it('should respond with 200 OK', function(done) {
+
       api.get('/')
       .set('Accept', 'application/json')
       .expect(200)
@@ -16,7 +17,7 @@ describe('/', function() {
           return;
         }
 
-        assert.property(res, 'name');
+        assert.isNull(res);
         done();
       });
     });

--- a/test/minimal/compare/output8__Stub.js
+++ b/test/minimal/compare/output8__Stub.js
@@ -7,6 +7,7 @@ var api = supertest('http://localhost:10010'); // supertest init;
 describe('/', function() {
   describe('get', function() {
     it('should respond with 200 OK', function(done) {
+
       api.get('/')
       .set('Accept', 'application/json')
       .expect(200)
@@ -16,7 +17,7 @@ describe('/', function() {
           return;
         }
 
-        expect(res).to.have.property('name');
+        expect(res).to.equal(null);
         done();
       });
     });

--- a/test/minimal/test.js
+++ b/test/minimal/test.js
@@ -89,7 +89,7 @@ describe('minimal swagger', function() {
         }
       }
 
-      it('should crea specified paths from pathName flag w/should', function() {
+      it('should make specified paths from pathName flag w/should', function() {
         assert.isArray(output2);
         assert.lengthOf(output2, 1);
 

--- a/test/robust/compare/output1__Stub.js
+++ b/test/robust/compare/output1__Stub.js
@@ -1,5 +1,7 @@
 'use strict';
 var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
 
 chai.should();
 var request = require('request');
@@ -7,6 +9,20 @@ var request = require('request');
 describe('/', function() {
   describe('get', function() {
     it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "username": {
+            "type": "string"
+          }
+        }
+      };
+      /*eslint-enable*/
+
       request({
         url: 'https://api.uber.com/test/',
         method: 'GET',
@@ -18,12 +34,23 @@ describe('/', function() {
           return;
         }
 
-        body.should.have.property('name');
+        validator.validate(body, schema).should.be.true;
+
         done();
       });
     });
 
     it('should respond with 400 NOT OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "properties": {
+          "meta": "string",
+          "data": "number"
+        }
+      };
+      /*eslint-enable*/
+
       request({
         url: 'https://api.uber.com/test/',
         method: 'GET',
@@ -35,12 +62,35 @@ describe('/', function() {
           return;
         }
 
-        body.should.have.property('name');
+        validator.validate(body, schema).should.be.true;
+
         done();
       });
     });
 
     it('should respond with 500 SERVER ERROR', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "properties": {
+          "meta": "string",
+          "data": "number",
+          "UserObj": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "integer"
+                },
+                "username": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+
       request({
         url: 'https://api.uber.com/test/',
         method: 'GET',
@@ -52,7 +102,8 @@ describe('/', function() {
           return;
         }
 
-        body.should.have.property('name');
+        validator.validate(body, schema).should.be.true;
+
         done();
       });
     });
@@ -61,6 +112,23 @@ describe('/', function() {
 
   describe('post', function() {
     it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "integer"
+            },
+            "username": {
+              "type": "string"
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+
       request({
         url: 'https://api.uber.com/test/',
         method: 'POST',
@@ -75,12 +143,19 @@ describe('/', function() {
           return;
         }
 
-        body.should.have.property('name');
+        validator.validate(body, schema).should.be.true;
+
         done();
       });
     });
 
     it('should respond with 400 NOT OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "number"
+      };
+      /*eslint-enable*/
+
       request({
         url: 'https://api.uber.com/test/',
         method: 'POST',
@@ -95,12 +170,19 @@ describe('/', function() {
           return;
         }
 
-        body.should.have.property('name');
+        validator.validate(body, schema).should.be.true;
+
         done();
       });
     });
 
     it('should respond with 500 SERVER ERROR', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "string"
+      };
+      /*eslint-enable*/
+
       request({
         url: 'https://api.uber.com/test/',
         method: 'POST',
@@ -115,7 +197,8 @@ describe('/', function() {
           return;
         }
 
-        body.should.have.property('name');
+        validator.validate(body, schema).should.be.true;
+
         done();
       });
     });

--- a/test/robust/compare/output1_user_Stub.js
+++ b/test/robust/compare/output1_user_Stub.js
@@ -7,6 +7,7 @@ var request = require('request');
 describe('/user', function() {
   describe('get', function() {
     it('should respond with 200 OK', function(done) {
+
       request({
         url: 'https://api.uber.com/test/user',
         method: 'GET',
@@ -18,12 +19,13 @@ describe('/user', function() {
           return;
         }
 
-        body.should.have.property('name');
+        body.should.equal(null);
         done();
       });
     });
 
     it('should respond with 400 NOT OK', function(done) {
+
       request({
         url: 'https://api.uber.com/test/user',
         method: 'GET',
@@ -35,12 +37,13 @@ describe('/user', function() {
           return;
         }
 
-        body.should.have.property('name');
+        body.should.equal(null);
         done();
       });
     });
 
     it('should respond with 500 SERVER ERROR', function(done) {
+
       request({
         url: 'https://api.uber.com/test/user',
         method: 'GET',
@@ -52,7 +55,7 @@ describe('/user', function() {
           return;
         }
 
-        body.should.have.property('name');
+        body.should.equal(null);
         done();
       });
     });
@@ -61,6 +64,7 @@ describe('/user', function() {
 
   describe('post', function() {
     it('should respond with 200 OK', function(done) {
+
       request({
         url: 'https://api.uber.com/test/user',
         method: 'POST',
@@ -75,12 +79,13 @@ describe('/user', function() {
           return;
         }
 
-        body.should.have.property('name');
+        body.should.equal(null);
         done();
       });
     });
 
     it('should respond with 400 NOT OK', function(done) {
+
       request({
         url: 'https://api.uber.com/test/user',
         method: 'POST',
@@ -95,12 +100,13 @@ describe('/user', function() {
           return;
         }
 
-        body.should.have.property('name');
+        body.should.equal(null);
         done();
       });
     });
 
     it('should respond with 500 SERVER ERROR', function(done) {
+
       request({
         url: 'https://api.uber.com/test/user',
         method: 'POST',
@@ -115,7 +121,7 @@ describe('/user', function() {
           return;
         }
 
-        body.should.have.property('name');
+        body.should.equal(null);
         done();
       });
     });

--- a/test/robust/compare/output2__Stub.js
+++ b/test/robust/compare/output2__Stub.js
@@ -1,5 +1,7 @@
 'use strict';
 var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
 
 chai.should();
 var request = require('request');
@@ -7,6 +9,20 @@ var request = require('request');
 describe('/', function() {
   describe('get', function() {
     it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "username": {
+            "type": "string"
+          }
+        }
+      };
+      /*eslint-enable*/
+
       request({
         url: 'https://api.uber.com/test/',
         method: 'GET',
@@ -18,12 +34,23 @@ describe('/', function() {
           return;
         }
 
-        body.should.have.property('name');
+        validator.validate(body, schema).should.be.true;
+
         done();
       });
     });
 
     it('should respond with 400 NOT OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "properties": {
+          "meta": "string",
+          "data": "number"
+        }
+      };
+      /*eslint-enable*/
+
       request({
         url: 'https://api.uber.com/test/',
         method: 'GET',
@@ -35,12 +62,35 @@ describe('/', function() {
           return;
         }
 
-        body.should.have.property('name');
+        validator.validate(body, schema).should.be.true;
+
         done();
       });
     });
 
     it('should respond with 500 SERVER ERROR', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "properties": {
+          "meta": "string",
+          "data": "number",
+          "UserObj": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "integer"
+                },
+                "username": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+
       request({
         url: 'https://api.uber.com/test/',
         method: 'GET',
@@ -52,7 +102,8 @@ describe('/', function() {
           return;
         }
 
-        body.should.have.property('name');
+        validator.validate(body, schema).should.be.true;
+
         done();
       });
     });
@@ -61,6 +112,23 @@ describe('/', function() {
 
   describe('post', function() {
     it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "integer"
+            },
+            "username": {
+              "type": "string"
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+
       request({
         url: 'https://api.uber.com/test/',
         method: 'POST',
@@ -75,12 +143,19 @@ describe('/', function() {
           return;
         }
 
-        body.should.have.property('name');
+        validator.validate(body, schema).should.be.true;
+
         done();
       });
     });
 
     it('should respond with 400 NOT OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "number"
+      };
+      /*eslint-enable*/
+
       request({
         url: 'https://api.uber.com/test/',
         method: 'POST',
@@ -95,12 +170,19 @@ describe('/', function() {
           return;
         }
 
-        body.should.have.property('name');
+        validator.validate(body, schema).should.be.true;
+
         done();
       });
     });
 
     it('should respond with 500 SERVER ERROR', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "string"
+      };
+      /*eslint-enable*/
+
       request({
         url: 'https://api.uber.com/test/',
         method: 'POST',
@@ -115,7 +197,8 @@ describe('/', function() {
           return;
         }
 
-        body.should.have.property('name');
+        validator.validate(body, schema).should.be.true;
+
         done();
       });
     });

--- a/test/robust/compare/output3__Stub.js
+++ b/test/robust/compare/output3__Stub.js
@@ -1,5 +1,7 @@
 'use strict';
 var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
 
 chai.should();
 var supertest = require('supertest');
@@ -8,6 +10,20 @@ var api = supertest('https://api.uber.com'); // supertest init;
 describe('/', function() {
   describe('get', function() {
     it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "username": {
+            "type": "string"
+          }
+        }
+      };
+      /*eslint-enable*/
+
       api.get('/test/')
       .set('Accept', 'application/json')
       .expect(200)
@@ -17,12 +33,23 @@ describe('/', function() {
           return;
         }
 
-        res.should.have.property('name');
+        validator.validate(res, schema).should.be.true;
+
         done();
       });
     });
 
     it('should respond with 400 NOT OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "properties": {
+          "meta": "string",
+          "data": "number"
+        }
+      };
+      /*eslint-enable*/
+
       api.get('/test/')
       .set('Accept', 'application/json')
       .expect(400)
@@ -32,12 +59,35 @@ describe('/', function() {
           return;
         }
 
-        res.should.have.property('name');
+        validator.validate(res, schema).should.be.true;
+
         done();
       });
     });
 
     it('should respond with 500 SERVER ERROR', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "properties": {
+          "meta": "string",
+          "data": "number",
+          "UserObj": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "integer"
+                },
+                "username": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+
       api.get('/test/')
       .set('Accept', 'application/json')
       .expect(500)
@@ -47,7 +97,8 @@ describe('/', function() {
           return;
         }
 
-        res.should.have.property('name');
+        validator.validate(res, schema).should.be.true;
+
         done();
       });
     });
@@ -56,6 +107,23 @@ describe('/', function() {
 
   describe('post', function() {
     it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "integer"
+            },
+            "username": {
+              "type": "string"
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+
       api.post('/test/')
       .set('Accept', 'application/json')
       .send({
@@ -68,12 +136,19 @@ describe('/', function() {
           return;
         }
 
-        res.should.have.property('name');
+        validator.validate(res, schema).should.be.true;
+
         done();
       });
     });
 
     it('should respond with 400 NOT OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "number"
+      };
+      /*eslint-enable*/
+
       api.post('/test/')
       .set('Accept', 'application/json')
       .send({
@@ -86,12 +161,19 @@ describe('/', function() {
           return;
         }
 
-        res.should.have.property('name');
+        validator.validate(res, schema).should.be.true;
+
         done();
       });
     });
 
     it('should respond with 500 SERVER ERROR', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "string"
+      };
+      /*eslint-enable*/
+
       api.post('/test/')
       .set('Accept', 'application/json')
       .send({
@@ -104,7 +186,8 @@ describe('/', function() {
           return;
         }
 
-        res.should.have.property('name');
+        validator.validate(res, schema).should.be.true;
+
         done();
       });
     });

--- a/test/robust/compare/output3_user_Stub.js
+++ b/test/robust/compare/output3_user_Stub.js
@@ -8,6 +8,7 @@ var api = supertest('https://api.uber.com'); // supertest init;
 describe('/user', function() {
   describe('get', function() {
     it('should respond with 200 OK', function(done) {
+
       api.get('/test/user')
       .set('Accept', 'application/json')
       .expect(200)
@@ -17,12 +18,13 @@ describe('/user', function() {
           return;
         }
 
-        res.should.have.property('name');
+        res.should.equal(null);
         done();
       });
     });
 
     it('should respond with 400 NOT OK', function(done) {
+
       api.get('/test/user')
       .set('Accept', 'application/json')
       .expect(400)
@@ -32,12 +34,13 @@ describe('/user', function() {
           return;
         }
 
-        res.should.have.property('name');
+        res.should.equal(null);
         done();
       });
     });
 
     it('should respond with 500 SERVER ERROR', function(done) {
+
       api.get('/test/user')
       .set('Accept', 'application/json')
       .expect(500)
@@ -47,7 +50,7 @@ describe('/user', function() {
           return;
         }
 
-        res.should.have.property('name');
+        res.should.equal(null);
         done();
       });
     });
@@ -56,6 +59,7 @@ describe('/user', function() {
 
   describe('post', function() {
     it('should respond with 200 OK', function(done) {
+
       api.post('/test/user')
       .set('Accept', 'application/json')
       .send({
@@ -68,12 +72,13 @@ describe('/user', function() {
           return;
         }
 
-        res.should.have.property('name');
+        res.should.equal(null);
         done();
       });
     });
 
     it('should respond with 400 NOT OK', function(done) {
+
       api.post('/test/user')
       .set('Accept', 'application/json')
       .send({
@@ -86,12 +91,13 @@ describe('/user', function() {
           return;
         }
 
-        res.should.have.property('name');
+        res.should.equal(null);
         done();
       });
     });
 
     it('should respond with 500 SERVER ERROR', function(done) {
+
       api.post('/test/user')
       .set('Accept', 'application/json')
       .send({
@@ -104,7 +110,7 @@ describe('/user', function() {
           return;
         }
 
-        res.should.have.property('name');
+        res.should.equal(null);
         done();
       });
     });

--- a/test/robust/compare/output4__Stub.js
+++ b/test/robust/compare/output4__Stub.js
@@ -1,5 +1,7 @@
 'use strict';
 var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
 
 chai.should();
 var supertest = require('supertest');
@@ -8,6 +10,20 @@ var api = supertest('https://api.uber.com'); // supertest init;
 describe('/', function() {
   describe('get', function() {
     it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "username": {
+            "type": "string"
+          }
+        }
+      };
+      /*eslint-enable*/
+
       api.get('/test/')
       .set('Accept', 'application/json')
       .expect(200)
@@ -17,12 +33,23 @@ describe('/', function() {
           return;
         }
 
-        res.should.have.property('name');
+        validator.validate(res, schema).should.be.true;
+
         done();
       });
     });
 
     it('should respond with 400 NOT OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "properties": {
+          "meta": "string",
+          "data": "number"
+        }
+      };
+      /*eslint-enable*/
+
       api.get('/test/')
       .set('Accept', 'application/json')
       .expect(400)
@@ -32,12 +59,35 @@ describe('/', function() {
           return;
         }
 
-        res.should.have.property('name');
+        validator.validate(res, schema).should.be.true;
+
         done();
       });
     });
 
     it('should respond with 500 SERVER ERROR', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "properties": {
+          "meta": "string",
+          "data": "number",
+          "UserObj": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "integer"
+                },
+                "username": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+
       api.get('/test/')
       .set('Accept', 'application/json')
       .expect(500)
@@ -47,7 +97,8 @@ describe('/', function() {
           return;
         }
 
-        res.should.have.property('name');
+        validator.validate(res, schema).should.be.true;
+
         done();
       });
     });
@@ -56,6 +107,23 @@ describe('/', function() {
 
   describe('post', function() {
     it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "integer"
+            },
+            "username": {
+              "type": "string"
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+
       api.post('/test/')
       .set('Accept', 'application/json')
       .send({
@@ -68,12 +136,19 @@ describe('/', function() {
           return;
         }
 
-        res.should.have.property('name');
+        validator.validate(res, schema).should.be.true;
+
         done();
       });
     });
 
     it('should respond with 400 NOT OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "number"
+      };
+      /*eslint-enable*/
+
       api.post('/test/')
       .set('Accept', 'application/json')
       .send({
@@ -86,12 +161,19 @@ describe('/', function() {
           return;
         }
 
-        res.should.have.property('name');
+        validator.validate(res, schema).should.be.true;
+
         done();
       });
     });
 
     it('should respond with 500 SERVER ERROR', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "string"
+      };
+      /*eslint-enable*/
+
       api.post('/test/')
       .set('Accept', 'application/json')
       .send({
@@ -104,7 +186,8 @@ describe('/', function() {
           return;
         }
 
-        res.should.have.property('name');
+        validator.validate(res, schema).should.be.true;
+
         done();
       });
     });

--- a/test/robust/compare/output5__Stub.js
+++ b/test/robust/compare/output5__Stub.js
@@ -1,11 +1,27 @@
 'use strict';
 var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
 var assert = chai.assert;
 var request = require('request');
 
 describe('/', function() {
   describe('get', function() {
     it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "username": {
+            "type": "string"
+          }
+        }
+      };
+      /*eslint-enable*/
+
       request({
         url: 'https://api.uber.com/test/',
         method: 'GET',
@@ -17,12 +33,22 @@ describe('/', function() {
           return;
         }
 
-        assert.property(body, 'name');
+        assert.true(validator.validate(body, schema));
         done();
       });
     });
 
     it('should respond with 400 NOT OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "properties": {
+          "meta": "string",
+          "data": "number"
+        }
+      };
+      /*eslint-enable*/
+
       request({
         url: 'https://api.uber.com/test/',
         method: 'GET',
@@ -34,12 +60,34 @@ describe('/', function() {
           return;
         }
 
-        assert.property(body, 'name');
+        assert.true(validator.validate(body, schema));
         done();
       });
     });
 
     it('should respond with 500 SERVER ERROR', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "properties": {
+          "meta": "string",
+          "data": "number",
+          "UserObj": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "integer"
+                },
+                "username": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+
       request({
         url: 'https://api.uber.com/test/',
         method: 'GET',
@@ -51,7 +99,7 @@ describe('/', function() {
           return;
         }
 
-        assert.property(body, 'name');
+        assert.true(validator.validate(body, schema));
         done();
       });
     });
@@ -60,6 +108,23 @@ describe('/', function() {
 
   describe('post', function() {
     it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "integer"
+            },
+            "username": {
+              "type": "string"
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+
       request({
         url: 'https://api.uber.com/test/',
         method: 'POST',
@@ -74,12 +139,18 @@ describe('/', function() {
           return;
         }
 
-        assert.property(body, 'name');
+        assert.true(validator.validate(body, schema));
         done();
       });
     });
 
     it('should respond with 400 NOT OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "number"
+      };
+      /*eslint-enable*/
+
       request({
         url: 'https://api.uber.com/test/',
         method: 'POST',
@@ -94,12 +165,18 @@ describe('/', function() {
           return;
         }
 
-        assert.property(body, 'name');
+        assert.true(validator.validate(body, schema));
         done();
       });
     });
 
     it('should respond with 500 SERVER ERROR', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "string"
+      };
+      /*eslint-enable*/
+
       request({
         url: 'https://api.uber.com/test/',
         method: 'POST',
@@ -114,7 +191,7 @@ describe('/', function() {
           return;
         }
 
-        assert.property(body, 'name');
+        assert.true(validator.validate(body, schema));
         done();
       });
     });

--- a/test/robust/compare/output5_user_Stub.js
+++ b/test/robust/compare/output5_user_Stub.js
@@ -6,6 +6,7 @@ var request = require('request');
 describe('/user', function() {
   describe('get', function() {
     it('should respond with 200 OK', function(done) {
+
       request({
         url: 'https://api.uber.com/test/user',
         method: 'GET',
@@ -17,12 +18,13 @@ describe('/user', function() {
           return;
         }
 
-        assert.property(body, 'name');
+        assert.isNull(body);
         done();
       });
     });
 
     it('should respond with 400 NOT OK', function(done) {
+
       request({
         url: 'https://api.uber.com/test/user',
         method: 'GET',
@@ -34,12 +36,13 @@ describe('/user', function() {
           return;
         }
 
-        assert.property(body, 'name');
+        assert.isNull(body);
         done();
       });
     });
 
     it('should respond with 500 SERVER ERROR', function(done) {
+
       request({
         url: 'https://api.uber.com/test/user',
         method: 'GET',
@@ -51,7 +54,7 @@ describe('/user', function() {
           return;
         }
 
-        assert.property(body, 'name');
+        assert.isNull(body);
         done();
       });
     });
@@ -60,6 +63,7 @@ describe('/user', function() {
 
   describe('post', function() {
     it('should respond with 200 OK', function(done) {
+
       request({
         url: 'https://api.uber.com/test/user',
         method: 'POST',
@@ -74,12 +78,13 @@ describe('/user', function() {
           return;
         }
 
-        assert.property(body, 'name');
+        assert.isNull(body);
         done();
       });
     });
 
     it('should respond with 400 NOT OK', function(done) {
+
       request({
         url: 'https://api.uber.com/test/user',
         method: 'POST',
@@ -94,12 +99,13 @@ describe('/user', function() {
           return;
         }
 
-        assert.property(body, 'name');
+        assert.isNull(body);
         done();
       });
     });
 
     it('should respond with 500 SERVER ERROR', function(done) {
+
       request({
         url: 'https://api.uber.com/test/user',
         method: 'POST',
@@ -114,7 +120,7 @@ describe('/user', function() {
           return;
         }
 
-        assert.property(body, 'name');
+        assert.isNull(body);
         done();
       });
     });

--- a/test/robust/compare/output6__Stub.js
+++ b/test/robust/compare/output6__Stub.js
@@ -1,11 +1,27 @@
 'use strict';
 var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
 var expect = chai.expect;
 var request = require('request');
 
 describe('/', function() {
   describe('get', function() {
     it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "username": {
+            "type": "string"
+          }
+        }
+      };
+      /*eslint-enable*/
+
       request({
         url: 'https://api.uber.com/test/',
         method: 'GET',
@@ -17,12 +33,23 @@ describe('/', function() {
           return;
         }
 
-        expect(body).to.have.property('name');
+        expect(validator.validate(body, schema)).to.be.true;
+
         done();
       });
     });
 
     it('should respond with 400 NOT OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "properties": {
+          "meta": "string",
+          "data": "number"
+        }
+      };
+      /*eslint-enable*/
+
       request({
         url: 'https://api.uber.com/test/',
         method: 'GET',
@@ -34,12 +61,35 @@ describe('/', function() {
           return;
         }
 
-        expect(body).to.have.property('name');
+        expect(validator.validate(body, schema)).to.be.true;
+
         done();
       });
     });
 
     it('should respond with 500 SERVER ERROR', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "properties": {
+          "meta": "string",
+          "data": "number",
+          "UserObj": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "integer"
+                },
+                "username": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+
       request({
         url: 'https://api.uber.com/test/',
         method: 'GET',
@@ -51,7 +101,8 @@ describe('/', function() {
           return;
         }
 
-        expect(body).to.have.property('name');
+        expect(validator.validate(body, schema)).to.be.true;
+
         done();
       });
     });
@@ -60,6 +111,23 @@ describe('/', function() {
 
   describe('post', function() {
     it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "integer"
+            },
+            "username": {
+              "type": "string"
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+
       request({
         url: 'https://api.uber.com/test/',
         method: 'POST',
@@ -74,12 +142,19 @@ describe('/', function() {
           return;
         }
 
-        expect(body).to.have.property('name');
+        expect(validator.validate(body, schema)).to.be.true;
+
         done();
       });
     });
 
     it('should respond with 400 NOT OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "number"
+      };
+      /*eslint-enable*/
+
       request({
         url: 'https://api.uber.com/test/',
         method: 'POST',
@@ -94,12 +169,19 @@ describe('/', function() {
           return;
         }
 
-        expect(body).to.have.property('name');
+        expect(validator.validate(body, schema)).to.be.true;
+
         done();
       });
     });
 
     it('should respond with 500 SERVER ERROR', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "string"
+      };
+      /*eslint-enable*/
+
       request({
         url: 'https://api.uber.com/test/',
         method: 'POST',
@@ -114,7 +196,8 @@ describe('/', function() {
           return;
         }
 
-        expect(body).to.have.property('name');
+        expect(validator.validate(body, schema)).to.be.true;
+
         done();
       });
     });

--- a/test/robust/compare/output6_user_Stub.js
+++ b/test/robust/compare/output6_user_Stub.js
@@ -6,6 +6,7 @@ var request = require('request');
 describe('/user', function() {
   describe('get', function() {
     it('should respond with 200 OK', function(done) {
+
       request({
         url: 'https://api.uber.com/test/user',
         method: 'GET',
@@ -17,12 +18,13 @@ describe('/user', function() {
           return;
         }
 
-        expect(body).to.have.property('name');
+        expect(body).to.equal(null);
         done();
       });
     });
 
     it('should respond with 400 NOT OK', function(done) {
+
       request({
         url: 'https://api.uber.com/test/user',
         method: 'GET',
@@ -34,12 +36,13 @@ describe('/user', function() {
           return;
         }
 
-        expect(body).to.have.property('name');
+        expect(body).to.equal(null);
         done();
       });
     });
 
     it('should respond with 500 SERVER ERROR', function(done) {
+
       request({
         url: 'https://api.uber.com/test/user',
         method: 'GET',
@@ -51,7 +54,7 @@ describe('/user', function() {
           return;
         }
 
-        expect(body).to.have.property('name');
+        expect(body).to.equal(null);
         done();
       });
     });
@@ -60,6 +63,7 @@ describe('/user', function() {
 
   describe('post', function() {
     it('should respond with 200 OK', function(done) {
+
       request({
         url: 'https://api.uber.com/test/user',
         method: 'POST',
@@ -74,12 +78,13 @@ describe('/user', function() {
           return;
         }
 
-        expect(body).to.have.property('name');
+        expect(body).to.equal(null);
         done();
       });
     });
 
     it('should respond with 400 NOT OK', function(done) {
+
       request({
         url: 'https://api.uber.com/test/user',
         method: 'POST',
@@ -94,12 +99,13 @@ describe('/user', function() {
           return;
         }
 
-        expect(body).to.have.property('name');
+        expect(body).to.equal(null);
         done();
       });
     });
 
     it('should respond with 500 SERVER ERROR', function(done) {
+
       request({
         url: 'https://api.uber.com/test/user',
         method: 'POST',
@@ -114,7 +120,7 @@ describe('/user', function() {
           return;
         }
 
-        expect(body).to.have.property('name');
+        expect(body).to.equal(null);
         done();
       });
     });

--- a/test/robust/compare/output7__Stub.js
+++ b/test/robust/compare/output7__Stub.js
@@ -1,5 +1,7 @@
 'use strict';
 var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
 var assert = chai.assert;
 var supertest = require('supertest');
 var api = supertest('https://api.uber.com'); // supertest init;
@@ -7,6 +9,20 @@ var api = supertest('https://api.uber.com'); // supertest init;
 describe('/', function() {
   describe('get', function() {
     it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "username": {
+            "type": "string"
+          }
+        }
+      };
+      /*eslint-enable*/
+
       api.get('/test/')
       .set('Accept', 'application/json')
       .expect(200)
@@ -16,12 +32,22 @@ describe('/', function() {
           return;
         }
 
-        assert.property(res, 'name');
+        assert.true(validator.validate(res, schema));
         done();
       });
     });
 
     it('should respond with 400 NOT OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "properties": {
+          "meta": "string",
+          "data": "number"
+        }
+      };
+      /*eslint-enable*/
+
       api.get('/test/')
       .set('Accept', 'application/json')
       .expect(400)
@@ -31,12 +57,34 @@ describe('/', function() {
           return;
         }
 
-        assert.property(res, 'name');
+        assert.true(validator.validate(res, schema));
         done();
       });
     });
 
     it('should respond with 500 SERVER ERROR', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "properties": {
+          "meta": "string",
+          "data": "number",
+          "UserObj": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "integer"
+                },
+                "username": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+
       api.get('/test/')
       .set('Accept', 'application/json')
       .expect(500)
@@ -46,7 +94,7 @@ describe('/', function() {
           return;
         }
 
-        assert.property(res, 'name');
+        assert.true(validator.validate(res, schema));
         done();
       });
     });
@@ -55,6 +103,23 @@ describe('/', function() {
 
   describe('post', function() {
     it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "integer"
+            },
+            "username": {
+              "type": "string"
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+
       api.post('/test/')
       .set('Accept', 'application/json')
       .send({
@@ -67,12 +132,18 @@ describe('/', function() {
           return;
         }
 
-        assert.property(res, 'name');
+        assert.true(validator.validate(res, schema));
         done();
       });
     });
 
     it('should respond with 400 NOT OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "number"
+      };
+      /*eslint-enable*/
+
       api.post('/test/')
       .set('Accept', 'application/json')
       .send({
@@ -85,12 +156,18 @@ describe('/', function() {
           return;
         }
 
-        assert.property(res, 'name');
+        assert.true(validator.validate(res, schema));
         done();
       });
     });
 
     it('should respond with 500 SERVER ERROR', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "string"
+      };
+      /*eslint-enable*/
+
       api.post('/test/')
       .set('Accept', 'application/json')
       .send({
@@ -103,7 +180,7 @@ describe('/', function() {
           return;
         }
 
-        assert.property(res, 'name');
+        assert.true(validator.validate(res, schema));
         done();
       });
     });

--- a/test/robust/compare/output7_user_Stub.js
+++ b/test/robust/compare/output7_user_Stub.js
@@ -7,6 +7,7 @@ var api = supertest('https://api.uber.com'); // supertest init;
 describe('/user', function() {
   describe('get', function() {
     it('should respond with 200 OK', function(done) {
+
       api.get('/test/user')
       .set('Accept', 'application/json')
       .expect(200)
@@ -16,12 +17,13 @@ describe('/user', function() {
           return;
         }
 
-        assert.property(res, 'name');
+        assert.isNull(res);
         done();
       });
     });
 
     it('should respond with 400 NOT OK', function(done) {
+
       api.get('/test/user')
       .set('Accept', 'application/json')
       .expect(400)
@@ -31,12 +33,13 @@ describe('/user', function() {
           return;
         }
 
-        assert.property(res, 'name');
+        assert.isNull(res);
         done();
       });
     });
 
     it('should respond with 500 SERVER ERROR', function(done) {
+
       api.get('/test/user')
       .set('Accept', 'application/json')
       .expect(500)
@@ -46,7 +49,7 @@ describe('/user', function() {
           return;
         }
 
-        assert.property(res, 'name');
+        assert.isNull(res);
         done();
       });
     });
@@ -55,6 +58,7 @@ describe('/user', function() {
 
   describe('post', function() {
     it('should respond with 200 OK', function(done) {
+
       api.post('/test/user')
       .set('Accept', 'application/json')
       .send({
@@ -67,12 +71,13 @@ describe('/user', function() {
           return;
         }
 
-        assert.property(res, 'name');
+        assert.isNull(res);
         done();
       });
     });
 
     it('should respond with 400 NOT OK', function(done) {
+
       api.post('/test/user')
       .set('Accept', 'application/json')
       .send({
@@ -85,12 +90,13 @@ describe('/user', function() {
           return;
         }
 
-        assert.property(res, 'name');
+        assert.isNull(res);
         done();
       });
     });
 
     it('should respond with 500 SERVER ERROR', function(done) {
+
       api.post('/test/user')
       .set('Accept', 'application/json')
       .send({
@@ -103,7 +109,7 @@ describe('/user', function() {
           return;
         }
 
-        assert.property(res, 'name');
+        assert.isNull(res);
         done();
       });
     });

--- a/test/robust/compare/output8__Stub.js
+++ b/test/robust/compare/output8__Stub.js
@@ -1,5 +1,7 @@
 'use strict';
 var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
 var expect = chai.expect;
 var supertest = require('supertest');
 var api = supertest('https://api.uber.com'); // supertest init;
@@ -7,6 +9,20 @@ var api = supertest('https://api.uber.com'); // supertest init;
 describe('/', function() {
   describe('get', function() {
     it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "username": {
+            "type": "string"
+          }
+        }
+      };
+      /*eslint-enable*/
+
       api.get('/test/')
       .set('Accept', 'application/json')
       .expect(200)
@@ -16,12 +32,23 @@ describe('/', function() {
           return;
         }
 
-        expect(res).to.have.property('name');
+        expect(validator.validate(res, schema)).to.be.true;
+
         done();
       });
     });
 
     it('should respond with 400 NOT OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "properties": {
+          "meta": "string",
+          "data": "number"
+        }
+      };
+      /*eslint-enable*/
+
       api.get('/test/')
       .set('Accept', 'application/json')
       .expect(400)
@@ -31,12 +58,35 @@ describe('/', function() {
           return;
         }
 
-        expect(res).to.have.property('name');
+        expect(validator.validate(res, schema)).to.be.true;
+
         done();
       });
     });
 
     it('should respond with 500 SERVER ERROR', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "properties": {
+          "meta": "string",
+          "data": "number",
+          "UserObj": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "integer"
+                },
+                "username": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+
       api.get('/test/')
       .set('Accept', 'application/json')
       .expect(500)
@@ -46,7 +96,8 @@ describe('/', function() {
           return;
         }
 
-        expect(res).to.have.property('name');
+        expect(validator.validate(res, schema)).to.be.true;
+
         done();
       });
     });
@@ -55,6 +106,23 @@ describe('/', function() {
 
   describe('post', function() {
     it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "integer"
+            },
+            "username": {
+              "type": "string"
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+
       api.post('/test/')
       .set('Accept', 'application/json')
       .send({
@@ -67,12 +135,19 @@ describe('/', function() {
           return;
         }
 
-        expect(res).to.have.property('name');
+        expect(validator.validate(res, schema)).to.be.true;
+
         done();
       });
     });
 
     it('should respond with 400 NOT OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "number"
+      };
+      /*eslint-enable*/
+
       api.post('/test/')
       .set('Accept', 'application/json')
       .send({
@@ -85,12 +160,19 @@ describe('/', function() {
           return;
         }
 
-        expect(res).to.have.property('name');
+        expect(validator.validate(res, schema)).to.be.true;
+
         done();
       });
     });
 
     it('should respond with 500 SERVER ERROR', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "string"
+      };
+      /*eslint-enable*/
+
       api.post('/test/')
       .set('Accept', 'application/json')
       .send({
@@ -103,7 +185,8 @@ describe('/', function() {
           return;
         }
 
-        expect(res).to.have.property('name');
+        expect(validator.validate(res, schema)).to.be.true;
+
         done();
       });
     });

--- a/test/robust/compare/output8_user_Stub.js
+++ b/test/robust/compare/output8_user_Stub.js
@@ -7,6 +7,7 @@ var api = supertest('https://api.uber.com'); // supertest init;
 describe('/user', function() {
   describe('get', function() {
     it('should respond with 200 OK', function(done) {
+
       api.get('/test/user')
       .set('Accept', 'application/json')
       .expect(200)
@@ -16,12 +17,13 @@ describe('/user', function() {
           return;
         }
 
-        expect(res).to.have.property('name');
+        expect(res).to.equal(null);
         done();
       });
     });
 
     it('should respond with 400 NOT OK', function(done) {
+
       api.get('/test/user')
       .set('Accept', 'application/json')
       .expect(400)
@@ -31,12 +33,13 @@ describe('/user', function() {
           return;
         }
 
-        expect(res).to.have.property('name');
+        expect(res).to.equal(null);
         done();
       });
     });
 
     it('should respond with 500 SERVER ERROR', function(done) {
+
       api.get('/test/user')
       .set('Accept', 'application/json')
       .expect(500)
@@ -46,7 +49,7 @@ describe('/user', function() {
           return;
         }
 
-        expect(res).to.have.property('name');
+        expect(res).to.equal(null);
         done();
       });
     });
@@ -55,6 +58,7 @@ describe('/user', function() {
 
   describe('post', function() {
     it('should respond with 200 OK', function(done) {
+
       api.post('/test/user')
       .set('Accept', 'application/json')
       .send({
@@ -67,12 +71,13 @@ describe('/user', function() {
           return;
         }
 
-        expect(res).to.have.property('name');
+        expect(res).to.equal(null);
         done();
       });
     });
 
     it('should respond with 400 NOT OK', function(done) {
+
       api.post('/test/user')
       .set('Accept', 'application/json')
       .send({
@@ -85,12 +90,13 @@ describe('/user', function() {
           return;
         }
 
-        expect(res).to.have.property('name');
+        expect(res).to.equal(null);
         done();
       });
     });
 
     it('should respond with 500 SERVER ERROR', function(done) {
+
       api.post('/test/user')
       .set('Accept', 'application/json')
       .send({
@@ -103,7 +109,7 @@ describe('/user', function() {
           return;
         }
 
-        expect(res).to.have.property('name');
+        expect(res).to.equal(null);
         done();
       });
     });

--- a/test/robust/swagger.json
+++ b/test/robust/swagger.json
@@ -14,13 +14,50 @@
             "get": {
                 "responses": {
                     "200": {
-                        "description": "OK"
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "id": {
+                                    "type": "integer"
+                                },
+                                "username": {
+                                    "type": "string"
+                                }
+                            }
+                        }
                     },
                     "400": {
-                        "description": "NOT OK"
+                        "description": "NOT OK",
+                        "schema": {
+                            "type":"object",
+                            "properties": {
+                                "meta": "string",
+                                "data": "number"
+                            }
+                        }
                     },
                     "500": {
-                        "description": "SERVER ERROR"
+                        "description": "SERVER ERROR",
+                        "schema": {
+                            "properties": {
+                                "meta":"string",
+                                "data":"number",
+                                "UserObj": {
+                                    "schema": {
+                                        "type": "object",
+                                        "properties": {
+                                            "id": {
+                                                "type": "integer"
+                                            },
+                                            "username": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
                     }
                 }
             },
@@ -45,13 +82,33 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "OK"
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "id": {
+                                        "type": "integer"
+                                    },
+                                    "username": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
                     },
                     "400": {
-                        "description": "NOT OK"
+                        "description": "NOT OK",
+                        "schema": {
+                            "type": "number"
+                        }
                     },
                     "500": {
-                        "description": "SERVER ERROR"
+                        "description": "SERVER ERROR",
+                        "schema": {
+                            "type": "string"
+                        }
                     }
                 }
             }
@@ -99,6 +156,19 @@
                     "500": {
                         "description": "SERVER ERROR"
                     }
+                }
+            }
+        }
+    },
+    "definitions": {
+        "User": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "integer"
+                },
+                "username": {
+                    "type": "string"
                 }
             }
         }


### PR DESCRIPTION
The response schema defined in the provided swagger is reflected in the assertions supplied in the generated code. The generated tests pull the schema of the operation being tested, and validate the response of the request against the expected schema.

Fixes #16 