### PR TITLE
Fix typo in quick-start guide in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ var testGen = require('swagger-test-templates');
 var swagger = require('/path/to/swagger.json');
 var config = {
   assertionFormat: 'should',
-  testmodule:'supertest',
+  testModule:'supertest',
   pathNames:['/user', '/user/{id}']
 };
 


### PR DESCRIPTION
`testModule` is the correct parameter name