### PR TITLE
Instagram tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,4 +73,3 @@ node_modules
 # Swagger Testing (swagger-test-template)
 ################################################################################
 .idea
-test/instagram

--- a/test/instagram/compare/output1/_geographies_{geo-id}_media_recent_Stub.js
+++ b/test/instagram/compare/output1/_geographies_{geo-id}_media_recent_Stub.js
@@ -1,0 +1,29 @@
+'use strict';
+var chai = require('chai');
+
+chai.should();
+var request = require('request');
+
+describe('/geographies/{geo-id}/media/recent', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+
+      request({
+        url: 'https://api.instagram.com/v1/geographies/{geo-id}/media/recent',
+        method: 'GET',
+        headers: {'Content-Type': 'application/json'}
+      },
+      function(error, response, body) {
+        if (error) {
+          done(error);
+          return;
+        }
+
+        body.should.equal(null);
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output1/_locations_search_Stub.js
+++ b/test/instagram/compare/output1/_locations_search_Stub.js
@@ -1,0 +1,45 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+
+chai.should();
+var request = require('request');
+
+describe('/locations/search', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Location"
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      request({
+        url: 'https://api.instagram.com/v1/locations/search',
+        method: 'GET',
+        headers: {'Content-Type': 'application/json'}
+      },
+      function(error, response, body) {
+        if (error) {
+          done(error);
+          return;
+        }
+
+        validator.validate(body, schema).should.be.true;
+
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output1/_locations_{location-id}_Stub.js
+++ b/test/instagram/compare/output1/_locations_{location-id}_Stub.js
@@ -1,0 +1,42 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+
+chai.should();
+var request = require('request');
+
+describe('/locations/{location-id}', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "properties": {
+          "data": {
+            "$ref": "#/definitions/Location"
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      request({
+        url: 'https://api.instagram.com/v1/locations/{location-id}',
+        method: 'GET',
+        headers: {'Content-Type': 'application/json'}
+      },
+      function(error, response, body) {
+        if (error) {
+          done(error);
+          return;
+        }
+
+        validator.validate(body, schema).should.be.true;
+
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output1/_locations_{location-id}_media_recent_Stub.js
+++ b/test/instagram/compare/output1/_locations_{location-id}_media_recent_Stub.js
@@ -1,0 +1,45 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+
+chai.should();
+var request = require('request');
+
+describe('/locations/{location-id}/media/recent', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Media"
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      request({
+        url: 'https://api.instagram.com/v1/locations/{location-id}/media/recent',
+        method: 'GET',
+        headers: {'Content-Type': 'application/json'}
+      },
+      function(error, response, body) {
+        if (error) {
+          done(error);
+          return;
+        }
+
+        validator.validate(body, schema).should.be.true;
+
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output1/_media1_{shortcode}_Stub.js
+++ b/test/instagram/compare/output1/_media1_{shortcode}_Stub.js
@@ -1,0 +1,37 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+
+chai.should();
+var request = require('request');
+
+describe('/media1/{shortcode}', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "$ref": "#/definitions/Media"
+      };
+      /*eslint-enable*/
+
+      request({
+        url: 'https://api.instagram.com/v1/media1/{shortcode}',
+        method: 'GET',
+        headers: {'Content-Type': 'application/json'}
+      },
+      function(error, response, body) {
+        if (error) {
+          done(error);
+          return;
+        }
+
+        validator.validate(body, schema).should.be.true;
+
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output1/_media_popular_Stub.js
+++ b/test/instagram/compare/output1/_media_popular_Stub.js
@@ -1,0 +1,45 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+
+chai.should();
+var request = require('request');
+
+describe('/media/popular', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Media"
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      request({
+        url: 'https://api.instagram.com/v1/media/popular',
+        method: 'GET',
+        headers: {'Content-Type': 'application/json'}
+      },
+      function(error, response, body) {
+        if (error) {
+          done(error);
+          return;
+        }
+
+        validator.validate(body, schema).should.be.true;
+
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output1/_media_search_Stub.js
+++ b/test/instagram/compare/output1/_media_search_Stub.js
@@ -1,0 +1,57 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+
+chai.should();
+var request = require('request');
+
+describe('/media/search', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "description": "List of all media with added `distance` property",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "allOf": [
+                {
+                  "$ref": "#/definitions/Media"
+                },
+                {
+                  "properties": {
+                    "distance": {
+                      "type": "number"
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      request({
+        url: 'https://api.instagram.com/v1/media/search',
+        method: 'GET',
+        headers: {'Content-Type': 'application/json'}
+      },
+      function(error, response, body) {
+        if (error) {
+          done(error);
+          return;
+        }
+
+        validator.validate(body, schema).should.be.true;
+
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output1/_media_{media-id}_Stub.js
+++ b/test/instagram/compare/output1/_media_{media-id}_Stub.js
@@ -1,0 +1,37 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+
+chai.should();
+var request = require('request');
+
+describe('/media/{media-id}', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "$ref": "#/definitions/Media"
+      };
+      /*eslint-enable*/
+
+      request({
+        url: 'https://api.instagram.com/v1/media/{media-id}',
+        method: 'GET',
+        headers: {'Content-Type': 'application/json'}
+      },
+      function(error, response, body) {
+        if (error) {
+          done(error);
+          return;
+        }
+
+        validator.validate(body, schema).should.be.true;
+
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output1/_media_{media-id}_comments_Stub.js
+++ b/test/instagram/compare/output1/_media_{media-id}_comments_Stub.js
@@ -1,0 +1,93 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+
+chai.should();
+var request = require('request');
+
+describe('/media/{media-id}/comments', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "properties": {
+          "meta": {
+            "properties": {
+              "code": {
+                "type": "number"
+              }
+            }
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Comment"
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      request({
+        url: 'https://api.instagram.com/v1/media/{media-id}/comments',
+        method: 'GET',
+        headers: {'Content-Type': 'application/json'}
+      },
+      function(error, response, body) {
+        if (error) {
+          done(error);
+          return;
+        }
+
+        validator.validate(body, schema).should.be.true;
+
+        done();
+      });
+    });
+
+  });
+
+  describe('post', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "properties": {
+          "meta": {
+            "properties": {
+              "code": {
+                "type": "number"
+              }
+            }
+          },
+          "data": {
+            "type": "object"
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      request({
+        url: 'https://api.instagram.com/v1/media/{media-id}/comments',
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        json: {
+          TEXT: 'DATA GOES HERE'
+        }
+      },
+      function(error, res, body) {
+        if (error) {
+          done(error);
+          return;
+        }
+
+        validator.validate(body, schema).should.be.true;
+
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output1/_media_{media-id}_likes_Stub.js
+++ b/test/instagram/compare/output1/_media_{media-id}_likes_Stub.js
@@ -1,0 +1,92 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+
+chai.should();
+var request = require('request');
+
+describe('/media/{media-id}/likes', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "properties": {
+          "meta": {
+            "properties": {
+              "code": {
+                "type": "number"
+              }
+            }
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Like"
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      request({
+        url: 'https://api.instagram.com/v1/media/{media-id}/likes',
+        method: 'GET',
+        headers: {'Content-Type': 'application/json'}
+      },
+      function(error, response, body) {
+        if (error) {
+          done(error);
+          return;
+        }
+
+        validator.validate(body, schema).should.be.true;
+
+        done();
+      });
+    });
+
+  });
+
+  describe('post', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "properties": {
+          "meta": {
+            "properties": {
+              "code": {
+                "type": "number"
+              }
+            }
+          },
+          "data": {
+            "type": "object"
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      request({
+        url: 'https://api.instagram.com/v1/media/{media-id}/likes',
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        json: {
+        }
+      },
+      function(error, res, body) {
+        if (error) {
+          done(error);
+          return;
+        }
+
+        validator.validate(body, schema).should.be.true;
+
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output1/_tags_search_Stub.js
+++ b/test/instagram/compare/output1/_tags_search_Stub.js
@@ -1,0 +1,52 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+
+chai.should();
+var request = require('request');
+
+describe('/tags/search', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "properties": {
+          "meta": {
+            "properties": {
+              "code": {
+                "type": "integer"
+              }
+            }
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Tag"
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      request({
+        url: 'https://api.instagram.com/v1/tags/search',
+        method: 'GET',
+        headers: {'Content-Type': 'application/json'}
+      },
+      function(error, response, body) {
+        if (error) {
+          done(error);
+          return;
+        }
+
+        validator.validate(body, schema).should.be.true;
+
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output1/_tags_{tag-name}_Stub.js
+++ b/test/instagram/compare/output1/_tags_{tag-name}_Stub.js
@@ -1,0 +1,37 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+
+chai.should();
+var request = require('request');
+
+describe('/tags/{tag-name}', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "$ref": "#/definitions/Tag"
+      };
+      /*eslint-enable*/
+
+      request({
+        url: 'https://api.instagram.com/v1/tags/{tag-name}',
+        method: 'GET',
+        headers: {'Content-Type': 'application/json'}
+      },
+      function(error, response, body) {
+        if (error) {
+          done(error);
+          return;
+        }
+
+        validator.validate(body, schema).should.be.true;
+
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output1/_tags_{tag-name}_media_recent_Stub.js
+++ b/test/instagram/compare/output1/_tags_{tag-name}_media_recent_Stub.js
@@ -1,0 +1,44 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+
+chai.should();
+var request = require('request');
+
+describe('/tags/{tag-name}/media/recent', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Tag"
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      request({
+        url: 'https://api.instagram.com/v1/tags/{tag-name}/media/recent',
+        method: 'GET',
+        headers: {'Content-Type': 'application/json'}
+      },
+      function(error, response, body) {
+        if (error) {
+          done(error);
+          return;
+        }
+
+        validator.validate(body, schema).should.be.true;
+
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output1/_users_search_Stub.js
+++ b/test/instagram/compare/output1/_users_search_Stub.js
@@ -1,0 +1,45 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+
+chai.should();
+var request = require('request');
+
+describe('/users/search', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/MiniProfile"
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      request({
+        url: 'https://api.instagram.com/v1/users/search',
+        method: 'GET',
+        headers: {'Content-Type': 'application/json'}
+      },
+      function(error, response, body) {
+        if (error) {
+          done(error);
+          return;
+        }
+
+        validator.validate(body, schema).should.be.true;
+
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output1/_users_self_feed_Stub.js
+++ b/test/instagram/compare/output1/_users_self_feed_Stub.js
@@ -1,0 +1,45 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+
+chai.should();
+var request = require('request');
+
+describe('/users/self/feed', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Media"
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      request({
+        url: 'https://api.instagram.com/v1/users/self/feed',
+        method: 'GET',
+        headers: {'Content-Type': 'application/json'}
+      },
+      function(error, response, body) {
+        if (error) {
+          done(error);
+          return;
+        }
+
+        validator.validate(body, schema).should.be.true;
+
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output1/_users_self_media_liked_Stub.js
+++ b/test/instagram/compare/output1/_users_self_media_liked_Stub.js
@@ -1,0 +1,45 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+
+chai.should();
+var request = require('request');
+
+describe('/users/self/media/liked', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Media"
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      request({
+        url: 'https://api.instagram.com/v1/users/self/media/liked',
+        method: 'GET',
+        headers: {'Content-Type': 'application/json'}
+      },
+      function(error, response, body) {
+        if (error) {
+          done(error);
+          return;
+        }
+
+        validator.validate(body, schema).should.be.true;
+
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output1/_users_self_requested-by_Stub.js
+++ b/test/instagram/compare/output1/_users_self_requested-by_Stub.js
@@ -1,0 +1,51 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+
+chai.should();
+var request = require('request');
+
+describe('/users/self/requested-by', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "properties": {
+          "meta": {
+            "properties": {
+              "code": {
+                "type": "integer"
+              }
+            }
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/MiniProfile"
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      request({
+        url: 'https://api.instagram.com/v1/users/self/requested-by',
+        method: 'GET',
+        headers: {'Content-Type': 'application/json'}
+      },
+      function(error, response, body) {
+        if (error) {
+          done(error);
+          return;
+        }
+
+        validator.validate(body, schema).should.be.true;
+
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output1/_users_{user-id}_Stub.js
+++ b/test/instagram/compare/output1/_users_{user-id}_Stub.js
@@ -1,0 +1,42 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+
+chai.should();
+var request = require('request');
+
+describe('/users/{user-id}', function() {
+  describe('get', function() {
+    it('should respond with 200 The user object', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "properties": {
+          "data": {
+            "$ref": "#/definitions/User"
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      request({
+        url: 'https://api.instagram.com/v1/users/{user-id}',
+        method: 'GET',
+        headers: {'Content-Type': 'application/json'}
+      },
+      function(error, response, body) {
+        if (error) {
+          done(error);
+          return;
+        }
+
+        validator.validate(body, schema).should.be.true;
+
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output1/_users_{user-id}_followed-by_Stub.js
+++ b/test/instagram/compare/output1/_users_{user-id}_followed-by_Stub.js
@@ -1,0 +1,44 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+
+chai.should();
+var request = require('request');
+
+describe('/users/{user-id}/followed-by', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/MiniProfile"
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      request({
+        url: 'https://api.instagram.com/v1/users/{user-id}/followed-by',
+        method: 'GET',
+        headers: {'Content-Type': 'application/json'}
+      },
+      function(error, response, body) {
+        if (error) {
+          done(error);
+          return;
+        }
+
+        validator.validate(body, schema).should.be.true;
+
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output1/_users_{user-id}_follows_Stub.js
+++ b/test/instagram/compare/output1/_users_{user-id}_follows_Stub.js
@@ -1,0 +1,44 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+
+chai.should();
+var request = require('request');
+
+describe('/users/{user-id}/follows', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/MiniProfile"
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      request({
+        url: 'https://api.instagram.com/v1/users/{user-id}/follows',
+        method: 'GET',
+        headers: {'Content-Type': 'application/json'}
+      },
+      function(error, response, body) {
+        if (error) {
+          done(error);
+          return;
+        }
+
+        validator.validate(body, schema).should.be.true;
+
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output1/_users_{user-id}_media_recent_Stub.js
+++ b/test/instagram/compare/output1/_users_{user-id}_media_recent_Stub.js
@@ -1,0 +1,48 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+
+chai.should();
+var request = require('request');
+
+describe('/users/{user-id}/media/recent', function() {
+  describe('get', function() {
+    it('should respond with 200 Get the most recent media published by a user. To get the most recent
+media published by the owner of the access token, you can use `self`
+instead of the `user-id`.
+', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Media"
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      request({
+        url: 'https://api.instagram.com/v1/users/{user-id}/media/recent',
+        method: 'GET',
+        headers: {'Content-Type': 'application/json'}
+      },
+      function(error, response, body) {
+        if (error) {
+          done(error);
+          return;
+        }
+
+        validator.validate(body, schema).should.be.true;
+
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output1/_users_{user-id}_relationship_Stub.js
+++ b/test/instagram/compare/output1/_users_{user-id}_relationship_Stub.js
@@ -1,0 +1,47 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+
+chai.should();
+var request = require('request');
+
+describe('/users/{user-id}/relationship', function() {
+  describe('post', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/MiniProfile"
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      request({
+        url: 'https://api.instagram.com/v1/users/{user-id}/relationship',
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        json: {
+          action: 'DATA GOES HERE'
+        }
+      },
+      function(error, res, body) {
+        if (error) {
+          done(error);
+          return;
+        }
+
+        validator.validate(body, schema).should.be.true;
+
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output2/_users_self_feed_Stub.js
+++ b/test/instagram/compare/output2/_users_self_feed_Stub.js
@@ -1,0 +1,45 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+
+chai.should();
+var request = require('request');
+
+describe('/users/self/feed', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Media"
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      request({
+        url: 'https://api.instagram.com/v1/users/self/feed',
+        method: 'GET',
+        headers: {'Content-Type': 'application/json'}
+      },
+      function(error, response, body) {
+        if (error) {
+          done(error);
+          return;
+        }
+
+        validator.validate(body, schema).should.be.true;
+
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output2/_users_self_requested-by_Stub.js
+++ b/test/instagram/compare/output2/_users_self_requested-by_Stub.js
@@ -1,0 +1,51 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+
+chai.should();
+var request = require('request');
+
+describe('/users/self/requested-by', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "properties": {
+          "meta": {
+            "properties": {
+              "code": {
+                "type": "integer"
+              }
+            }
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/MiniProfile"
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      request({
+        url: 'https://api.instagram.com/v1/users/self/requested-by',
+        method: 'GET',
+        headers: {'Content-Type': 'application/json'}
+      },
+      function(error, response, body) {
+        if (error) {
+          done(error);
+          return;
+        }
+
+        validator.validate(body, schema).should.be.true;
+
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output2/_users_{user-id}_Stub.js
+++ b/test/instagram/compare/output2/_users_{user-id}_Stub.js
@@ -1,0 +1,42 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+
+chai.should();
+var request = require('request');
+
+describe('/users/{user-id}', function() {
+  describe('get', function() {
+    it('should respond with 200 The user object', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "properties": {
+          "data": {
+            "$ref": "#/definitions/User"
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      request({
+        url: 'https://api.instagram.com/v1/users/{user-id}',
+        method: 'GET',
+        headers: {'Content-Type': 'application/json'}
+      },
+      function(error, response, body) {
+        if (error) {
+          done(error);
+          return;
+        }
+
+        validator.validate(body, schema).should.be.true;
+
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output3/_geographies_{geo-id}_media_recent_Stub.js
+++ b/test/instagram/compare/output3/_geographies_{geo-id}_media_recent_Stub.js
@@ -1,0 +1,28 @@
+'use strict';
+var chai = require('chai');
+var expect = chai.expect;
+var request = require('request');
+
+describe('/geographies/{geo-id}/media/recent', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+
+      request({
+        url: 'https://api.instagram.com/v1/geographies/{geo-id}/media/recent',
+        method: 'GET',
+        headers: {'Content-Type': 'application/json'}
+      },
+      function(error, response, body) {
+        if (error) {
+          done(error);
+          return;
+        }
+
+        expect(body).to.equal(null);
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output3/_locations_search_Stub.js
+++ b/test/instagram/compare/output3/_locations_search_Stub.js
@@ -1,0 +1,44 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+var expect = chai.expect;
+var request = require('request');
+
+describe('/locations/search', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Location"
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      request({
+        url: 'https://api.instagram.com/v1/locations/search',
+        method: 'GET',
+        headers: {'Content-Type': 'application/json'}
+      },
+      function(error, response, body) {
+        if (error) {
+          done(error);
+          return;
+        }
+
+        expect(validator.validate(body, schema)).to.be.true;
+
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output3/_locations_{location-id}_Stub.js
+++ b/test/instagram/compare/output3/_locations_{location-id}_Stub.js
@@ -1,0 +1,41 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+var expect = chai.expect;
+var request = require('request');
+
+describe('/locations/{location-id}', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "properties": {
+          "data": {
+            "$ref": "#/definitions/Location"
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      request({
+        url: 'https://api.instagram.com/v1/locations/{location-id}',
+        method: 'GET',
+        headers: {'Content-Type': 'application/json'}
+      },
+      function(error, response, body) {
+        if (error) {
+          done(error);
+          return;
+        }
+
+        expect(validator.validate(body, schema)).to.be.true;
+
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output3/_locations_{location-id}_media_recent_Stub.js
+++ b/test/instagram/compare/output3/_locations_{location-id}_media_recent_Stub.js
@@ -1,0 +1,44 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+var expect = chai.expect;
+var request = require('request');
+
+describe('/locations/{location-id}/media/recent', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Media"
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      request({
+        url: 'https://api.instagram.com/v1/locations/{location-id}/media/recent',
+        method: 'GET',
+        headers: {'Content-Type': 'application/json'}
+      },
+      function(error, response, body) {
+        if (error) {
+          done(error);
+          return;
+        }
+
+        expect(validator.validate(body, schema)).to.be.true;
+
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output3/_media1_{shortcode}_Stub.js
+++ b/test/instagram/compare/output3/_media1_{shortcode}_Stub.js
@@ -1,0 +1,36 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+var expect = chai.expect;
+var request = require('request');
+
+describe('/media1/{shortcode}', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "$ref": "#/definitions/Media"
+      };
+      /*eslint-enable*/
+
+      request({
+        url: 'https://api.instagram.com/v1/media1/{shortcode}',
+        method: 'GET',
+        headers: {'Content-Type': 'application/json'}
+      },
+      function(error, response, body) {
+        if (error) {
+          done(error);
+          return;
+        }
+
+        expect(validator.validate(body, schema)).to.be.true;
+
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output3/_media_popular_Stub.js
+++ b/test/instagram/compare/output3/_media_popular_Stub.js
@@ -1,0 +1,44 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+var expect = chai.expect;
+var request = require('request');
+
+describe('/media/popular', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Media"
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      request({
+        url: 'https://api.instagram.com/v1/media/popular',
+        method: 'GET',
+        headers: {'Content-Type': 'application/json'}
+      },
+      function(error, response, body) {
+        if (error) {
+          done(error);
+          return;
+        }
+
+        expect(validator.validate(body, schema)).to.be.true;
+
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output3/_media_search_Stub.js
+++ b/test/instagram/compare/output3/_media_search_Stub.js
@@ -1,0 +1,56 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+var expect = chai.expect;
+var request = require('request');
+
+describe('/media/search', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "description": "List of all media with added `distance` property",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "allOf": [
+                {
+                  "$ref": "#/definitions/Media"
+                },
+                {
+                  "properties": {
+                    "distance": {
+                      "type": "number"
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      request({
+        url: 'https://api.instagram.com/v1/media/search',
+        method: 'GET',
+        headers: {'Content-Type': 'application/json'}
+      },
+      function(error, response, body) {
+        if (error) {
+          done(error);
+          return;
+        }
+
+        expect(validator.validate(body, schema)).to.be.true;
+
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output3/_media_{media-id}_Stub.js
+++ b/test/instagram/compare/output3/_media_{media-id}_Stub.js
@@ -1,0 +1,36 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+var expect = chai.expect;
+var request = require('request');
+
+describe('/media/{media-id}', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "$ref": "#/definitions/Media"
+      };
+      /*eslint-enable*/
+
+      request({
+        url: 'https://api.instagram.com/v1/media/{media-id}',
+        method: 'GET',
+        headers: {'Content-Type': 'application/json'}
+      },
+      function(error, response, body) {
+        if (error) {
+          done(error);
+          return;
+        }
+
+        expect(validator.validate(body, schema)).to.be.true;
+
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output3/_media_{media-id}_comments_Stub.js
+++ b/test/instagram/compare/output3/_media_{media-id}_comments_Stub.js
@@ -1,0 +1,92 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+var expect = chai.expect;
+var request = require('request');
+
+describe('/media/{media-id}/comments', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "properties": {
+          "meta": {
+            "properties": {
+              "code": {
+                "type": "number"
+              }
+            }
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Comment"
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      request({
+        url: 'https://api.instagram.com/v1/media/{media-id}/comments',
+        method: 'GET',
+        headers: {'Content-Type': 'application/json'}
+      },
+      function(error, response, body) {
+        if (error) {
+          done(error);
+          return;
+        }
+
+        expect(validator.validate(body, schema)).to.be.true;
+
+        done();
+      });
+    });
+
+  });
+
+  describe('post', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "properties": {
+          "meta": {
+            "properties": {
+              "code": {
+                "type": "number"
+              }
+            }
+          },
+          "data": {
+            "type": "object"
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      request({
+        url: 'https://api.instagram.com/v1/media/{media-id}/comments',
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        json: {
+          TEXT: 'DATA GOES HERE'
+        }
+      },
+      function(error, res, body) {
+        if (error) {
+          done(error);
+          return;
+        }
+
+        expect(validator.validate(body, schema)).to.be.true;
+
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output3/_media_{media-id}_likes_Stub.js
+++ b/test/instagram/compare/output3/_media_{media-id}_likes_Stub.js
@@ -1,0 +1,91 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+var expect = chai.expect;
+var request = require('request');
+
+describe('/media/{media-id}/likes', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "properties": {
+          "meta": {
+            "properties": {
+              "code": {
+                "type": "number"
+              }
+            }
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Like"
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      request({
+        url: 'https://api.instagram.com/v1/media/{media-id}/likes',
+        method: 'GET',
+        headers: {'Content-Type': 'application/json'}
+      },
+      function(error, response, body) {
+        if (error) {
+          done(error);
+          return;
+        }
+
+        expect(validator.validate(body, schema)).to.be.true;
+
+        done();
+      });
+    });
+
+  });
+
+  describe('post', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "properties": {
+          "meta": {
+            "properties": {
+              "code": {
+                "type": "number"
+              }
+            }
+          },
+          "data": {
+            "type": "object"
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      request({
+        url: 'https://api.instagram.com/v1/media/{media-id}/likes',
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        json: {
+        }
+      },
+      function(error, res, body) {
+        if (error) {
+          done(error);
+          return;
+        }
+
+        expect(validator.validate(body, schema)).to.be.true;
+
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output3/_tags_search_Stub.js
+++ b/test/instagram/compare/output3/_tags_search_Stub.js
@@ -1,0 +1,51 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+var expect = chai.expect;
+var request = require('request');
+
+describe('/tags/search', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "properties": {
+          "meta": {
+            "properties": {
+              "code": {
+                "type": "integer"
+              }
+            }
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Tag"
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      request({
+        url: 'https://api.instagram.com/v1/tags/search',
+        method: 'GET',
+        headers: {'Content-Type': 'application/json'}
+      },
+      function(error, response, body) {
+        if (error) {
+          done(error);
+          return;
+        }
+
+        expect(validator.validate(body, schema)).to.be.true;
+
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output3/_tags_{tag-name}_Stub.js
+++ b/test/instagram/compare/output3/_tags_{tag-name}_Stub.js
@@ -1,0 +1,36 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+var expect = chai.expect;
+var request = require('request');
+
+describe('/tags/{tag-name}', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "$ref": "#/definitions/Tag"
+      };
+      /*eslint-enable*/
+
+      request({
+        url: 'https://api.instagram.com/v1/tags/{tag-name}',
+        method: 'GET',
+        headers: {'Content-Type': 'application/json'}
+      },
+      function(error, response, body) {
+        if (error) {
+          done(error);
+          return;
+        }
+
+        expect(validator.validate(body, schema)).to.be.true;
+
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output3/_tags_{tag-name}_media_recent_Stub.js
+++ b/test/instagram/compare/output3/_tags_{tag-name}_media_recent_Stub.js
@@ -1,0 +1,43 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+var expect = chai.expect;
+var request = require('request');
+
+describe('/tags/{tag-name}/media/recent', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Tag"
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      request({
+        url: 'https://api.instagram.com/v1/tags/{tag-name}/media/recent',
+        method: 'GET',
+        headers: {'Content-Type': 'application/json'}
+      },
+      function(error, response, body) {
+        if (error) {
+          done(error);
+          return;
+        }
+
+        expect(validator.validate(body, schema)).to.be.true;
+
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output3/_users_search_Stub.js
+++ b/test/instagram/compare/output3/_users_search_Stub.js
@@ -1,0 +1,44 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+var expect = chai.expect;
+var request = require('request');
+
+describe('/users/search', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/MiniProfile"
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      request({
+        url: 'https://api.instagram.com/v1/users/search',
+        method: 'GET',
+        headers: {'Content-Type': 'application/json'}
+      },
+      function(error, response, body) {
+        if (error) {
+          done(error);
+          return;
+        }
+
+        expect(validator.validate(body, schema)).to.be.true;
+
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output3/_users_self_feed_Stub.js
+++ b/test/instagram/compare/output3/_users_self_feed_Stub.js
@@ -1,0 +1,44 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+var expect = chai.expect;
+var request = require('request');
+
+describe('/users/self/feed', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Media"
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      request({
+        url: 'https://api.instagram.com/v1/users/self/feed',
+        method: 'GET',
+        headers: {'Content-Type': 'application/json'}
+      },
+      function(error, response, body) {
+        if (error) {
+          done(error);
+          return;
+        }
+
+        expect(validator.validate(body, schema)).to.be.true;
+
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output3/_users_self_media_liked_Stub.js
+++ b/test/instagram/compare/output3/_users_self_media_liked_Stub.js
@@ -1,0 +1,44 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+var expect = chai.expect;
+var request = require('request');
+
+describe('/users/self/media/liked', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Media"
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      request({
+        url: 'https://api.instagram.com/v1/users/self/media/liked',
+        method: 'GET',
+        headers: {'Content-Type': 'application/json'}
+      },
+      function(error, response, body) {
+        if (error) {
+          done(error);
+          return;
+        }
+
+        expect(validator.validate(body, schema)).to.be.true;
+
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output3/_users_self_requested-by_Stub.js
+++ b/test/instagram/compare/output3/_users_self_requested-by_Stub.js
@@ -1,0 +1,50 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+var expect = chai.expect;
+var request = require('request');
+
+describe('/users/self/requested-by', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "properties": {
+          "meta": {
+            "properties": {
+              "code": {
+                "type": "integer"
+              }
+            }
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/MiniProfile"
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      request({
+        url: 'https://api.instagram.com/v1/users/self/requested-by',
+        method: 'GET',
+        headers: {'Content-Type': 'application/json'}
+      },
+      function(error, response, body) {
+        if (error) {
+          done(error);
+          return;
+        }
+
+        expect(validator.validate(body, schema)).to.be.true;
+
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output3/_users_{user-id}_Stub.js
+++ b/test/instagram/compare/output3/_users_{user-id}_Stub.js
@@ -1,0 +1,41 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+var expect = chai.expect;
+var request = require('request');
+
+describe('/users/{user-id}', function() {
+  describe('get', function() {
+    it('should respond with 200 The user object', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "properties": {
+          "data": {
+            "$ref": "#/definitions/User"
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      request({
+        url: 'https://api.instagram.com/v1/users/{user-id}',
+        method: 'GET',
+        headers: {'Content-Type': 'application/json'}
+      },
+      function(error, response, body) {
+        if (error) {
+          done(error);
+          return;
+        }
+
+        expect(validator.validate(body, schema)).to.be.true;
+
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output3/_users_{user-id}_followed-by_Stub.js
+++ b/test/instagram/compare/output3/_users_{user-id}_followed-by_Stub.js
@@ -1,0 +1,43 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+var expect = chai.expect;
+var request = require('request');
+
+describe('/users/{user-id}/followed-by', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/MiniProfile"
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      request({
+        url: 'https://api.instagram.com/v1/users/{user-id}/followed-by',
+        method: 'GET',
+        headers: {'Content-Type': 'application/json'}
+      },
+      function(error, response, body) {
+        if (error) {
+          done(error);
+          return;
+        }
+
+        expect(validator.validate(body, schema)).to.be.true;
+
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output3/_users_{user-id}_follows_Stub.js
+++ b/test/instagram/compare/output3/_users_{user-id}_follows_Stub.js
@@ -1,0 +1,43 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+var expect = chai.expect;
+var request = require('request');
+
+describe('/users/{user-id}/follows', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/MiniProfile"
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      request({
+        url: 'https://api.instagram.com/v1/users/{user-id}/follows',
+        method: 'GET',
+        headers: {'Content-Type': 'application/json'}
+      },
+      function(error, response, body) {
+        if (error) {
+          done(error);
+          return;
+        }
+
+        expect(validator.validate(body, schema)).to.be.true;
+
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output3/_users_{user-id}_media_recent_Stub.js
+++ b/test/instagram/compare/output3/_users_{user-id}_media_recent_Stub.js
@@ -1,0 +1,47 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+var expect = chai.expect;
+var request = require('request');
+
+describe('/users/{user-id}/media/recent', function() {
+  describe('get', function() {
+    it('should respond with 200 Get the most recent media published by a user. To get the most recent
+media published by the owner of the access token, you can use `self`
+instead of the `user-id`.
+', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Media"
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      request({
+        url: 'https://api.instagram.com/v1/users/{user-id}/media/recent',
+        method: 'GET',
+        headers: {'Content-Type': 'application/json'}
+      },
+      function(error, response, body) {
+        if (error) {
+          done(error);
+          return;
+        }
+
+        expect(validator.validate(body, schema)).to.be.true;
+
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output3/_users_{user-id}_relationship_Stub.js
+++ b/test/instagram/compare/output3/_users_{user-id}_relationship_Stub.js
@@ -1,0 +1,46 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+var expect = chai.expect;
+var request = require('request');
+
+describe('/users/{user-id}/relationship', function() {
+  describe('post', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/MiniProfile"
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      request({
+        url: 'https://api.instagram.com/v1/users/{user-id}/relationship',
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        json: {
+          action: 'DATA GOES HERE'
+        }
+      },
+      function(error, res, body) {
+        if (error) {
+          done(error);
+          return;
+        }
+
+        expect(validator.validate(body, schema)).to.be.true;
+
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output4/_geographies_{geo-id}_media_recent_Stub.js
+++ b/test/instagram/compare/output4/_geographies_{geo-id}_media_recent_Stub.js
@@ -1,0 +1,28 @@
+'use strict';
+var chai = require('chai');
+var assert = chai.assert;
+var request = require('request');
+
+describe('/geographies/{geo-id}/media/recent', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+
+      request({
+        url: 'https://api.instagram.com/v1/geographies/{geo-id}/media/recent',
+        method: 'GET',
+        headers: {'Content-Type': 'application/json'}
+      },
+      function(error, response, body) {
+        if (error) {
+          done(error);
+          return;
+        }
+
+        assert.isNull(body);
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output4/_locations_search_Stub.js
+++ b/test/instagram/compare/output4/_locations_search_Stub.js
@@ -1,0 +1,43 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+var assert = chai.assert;
+var request = require('request');
+
+describe('/locations/search', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Location"
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      request({
+        url: 'https://api.instagram.com/v1/locations/search',
+        method: 'GET',
+        headers: {'Content-Type': 'application/json'}
+      },
+      function(error, response, body) {
+        if (error) {
+          done(error);
+          return;
+        }
+
+        assert.true(validator.validate(body, schema));
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output4/_locations_{location-id}_Stub.js
+++ b/test/instagram/compare/output4/_locations_{location-id}_Stub.js
@@ -1,0 +1,40 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+var assert = chai.assert;
+var request = require('request');
+
+describe('/locations/{location-id}', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "properties": {
+          "data": {
+            "$ref": "#/definitions/Location"
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      request({
+        url: 'https://api.instagram.com/v1/locations/{location-id}',
+        method: 'GET',
+        headers: {'Content-Type': 'application/json'}
+      },
+      function(error, response, body) {
+        if (error) {
+          done(error);
+          return;
+        }
+
+        assert.true(validator.validate(body, schema));
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output4/_locations_{location-id}_media_recent_Stub.js
+++ b/test/instagram/compare/output4/_locations_{location-id}_media_recent_Stub.js
@@ -1,0 +1,43 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+var assert = chai.assert;
+var request = require('request');
+
+describe('/locations/{location-id}/media/recent', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Media"
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      request({
+        url: 'https://api.instagram.com/v1/locations/{location-id}/media/recent',
+        method: 'GET',
+        headers: {'Content-Type': 'application/json'}
+      },
+      function(error, response, body) {
+        if (error) {
+          done(error);
+          return;
+        }
+
+        assert.true(validator.validate(body, schema));
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output4/_media1_{shortcode}_Stub.js
+++ b/test/instagram/compare/output4/_media1_{shortcode}_Stub.js
@@ -1,0 +1,35 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+var assert = chai.assert;
+var request = require('request');
+
+describe('/media1/{shortcode}', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "$ref": "#/definitions/Media"
+      };
+      /*eslint-enable*/
+
+      request({
+        url: 'https://api.instagram.com/v1/media1/{shortcode}',
+        method: 'GET',
+        headers: {'Content-Type': 'application/json'}
+      },
+      function(error, response, body) {
+        if (error) {
+          done(error);
+          return;
+        }
+
+        assert.true(validator.validate(body, schema));
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output4/_media_popular_Stub.js
+++ b/test/instagram/compare/output4/_media_popular_Stub.js
@@ -1,0 +1,43 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+var assert = chai.assert;
+var request = require('request');
+
+describe('/media/popular', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Media"
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      request({
+        url: 'https://api.instagram.com/v1/media/popular',
+        method: 'GET',
+        headers: {'Content-Type': 'application/json'}
+      },
+      function(error, response, body) {
+        if (error) {
+          done(error);
+          return;
+        }
+
+        assert.true(validator.validate(body, schema));
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output4/_media_search_Stub.js
+++ b/test/instagram/compare/output4/_media_search_Stub.js
@@ -1,0 +1,55 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+var assert = chai.assert;
+var request = require('request');
+
+describe('/media/search', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "description": "List of all media with added `distance` property",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "allOf": [
+                {
+                  "$ref": "#/definitions/Media"
+                },
+                {
+                  "properties": {
+                    "distance": {
+                      "type": "number"
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      request({
+        url: 'https://api.instagram.com/v1/media/search',
+        method: 'GET',
+        headers: {'Content-Type': 'application/json'}
+      },
+      function(error, response, body) {
+        if (error) {
+          done(error);
+          return;
+        }
+
+        assert.true(validator.validate(body, schema));
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output4/_media_{media-id}_Stub.js
+++ b/test/instagram/compare/output4/_media_{media-id}_Stub.js
@@ -1,0 +1,35 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+var assert = chai.assert;
+var request = require('request');
+
+describe('/media/{media-id}', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "$ref": "#/definitions/Media"
+      };
+      /*eslint-enable*/
+
+      request({
+        url: 'https://api.instagram.com/v1/media/{media-id}',
+        method: 'GET',
+        headers: {'Content-Type': 'application/json'}
+      },
+      function(error, response, body) {
+        if (error) {
+          done(error);
+          return;
+        }
+
+        assert.true(validator.validate(body, schema));
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output4/_media_{media-id}_comments_Stub.js
+++ b/test/instagram/compare/output4/_media_{media-id}_comments_Stub.js
@@ -1,0 +1,90 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+var assert = chai.assert;
+var request = require('request');
+
+describe('/media/{media-id}/comments', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "properties": {
+          "meta": {
+            "properties": {
+              "code": {
+                "type": "number"
+              }
+            }
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Comment"
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      request({
+        url: 'https://api.instagram.com/v1/media/{media-id}/comments',
+        method: 'GET',
+        headers: {'Content-Type': 'application/json'}
+      },
+      function(error, response, body) {
+        if (error) {
+          done(error);
+          return;
+        }
+
+        assert.true(validator.validate(body, schema));
+        done();
+      });
+    });
+
+  });
+
+  describe('post', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "properties": {
+          "meta": {
+            "properties": {
+              "code": {
+                "type": "number"
+              }
+            }
+          },
+          "data": {
+            "type": "object"
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      request({
+        url: 'https://api.instagram.com/v1/media/{media-id}/comments',
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        json: {
+          TEXT: 'DATA GOES HERE'
+        }
+      },
+      function(error, res, body) {
+        if (error) {
+          done(error);
+          return;
+        }
+
+        assert.true(validator.validate(body, schema));
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output4/_media_{media-id}_likes_Stub.js
+++ b/test/instagram/compare/output4/_media_{media-id}_likes_Stub.js
@@ -1,0 +1,89 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+var assert = chai.assert;
+var request = require('request');
+
+describe('/media/{media-id}/likes', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "properties": {
+          "meta": {
+            "properties": {
+              "code": {
+                "type": "number"
+              }
+            }
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Like"
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      request({
+        url: 'https://api.instagram.com/v1/media/{media-id}/likes',
+        method: 'GET',
+        headers: {'Content-Type': 'application/json'}
+      },
+      function(error, response, body) {
+        if (error) {
+          done(error);
+          return;
+        }
+
+        assert.true(validator.validate(body, schema));
+        done();
+      });
+    });
+
+  });
+
+  describe('post', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "properties": {
+          "meta": {
+            "properties": {
+              "code": {
+                "type": "number"
+              }
+            }
+          },
+          "data": {
+            "type": "object"
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      request({
+        url: 'https://api.instagram.com/v1/media/{media-id}/likes',
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        json: {
+        }
+      },
+      function(error, res, body) {
+        if (error) {
+          done(error);
+          return;
+        }
+
+        assert.true(validator.validate(body, schema));
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output4/_tags_search_Stub.js
+++ b/test/instagram/compare/output4/_tags_search_Stub.js
@@ -1,0 +1,50 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+var assert = chai.assert;
+var request = require('request');
+
+describe('/tags/search', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "properties": {
+          "meta": {
+            "properties": {
+              "code": {
+                "type": "integer"
+              }
+            }
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Tag"
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      request({
+        url: 'https://api.instagram.com/v1/tags/search',
+        method: 'GET',
+        headers: {'Content-Type': 'application/json'}
+      },
+      function(error, response, body) {
+        if (error) {
+          done(error);
+          return;
+        }
+
+        assert.true(validator.validate(body, schema));
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output4/_tags_{tag-name}_Stub.js
+++ b/test/instagram/compare/output4/_tags_{tag-name}_Stub.js
@@ -1,0 +1,35 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+var assert = chai.assert;
+var request = require('request');
+
+describe('/tags/{tag-name}', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "$ref": "#/definitions/Tag"
+      };
+      /*eslint-enable*/
+
+      request({
+        url: 'https://api.instagram.com/v1/tags/{tag-name}',
+        method: 'GET',
+        headers: {'Content-Type': 'application/json'}
+      },
+      function(error, response, body) {
+        if (error) {
+          done(error);
+          return;
+        }
+
+        assert.true(validator.validate(body, schema));
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output4/_tags_{tag-name}_media_recent_Stub.js
+++ b/test/instagram/compare/output4/_tags_{tag-name}_media_recent_Stub.js
@@ -1,0 +1,42 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+var assert = chai.assert;
+var request = require('request');
+
+describe('/tags/{tag-name}/media/recent', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Tag"
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      request({
+        url: 'https://api.instagram.com/v1/tags/{tag-name}/media/recent',
+        method: 'GET',
+        headers: {'Content-Type': 'application/json'}
+      },
+      function(error, response, body) {
+        if (error) {
+          done(error);
+          return;
+        }
+
+        assert.true(validator.validate(body, schema));
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output4/_users_search_Stub.js
+++ b/test/instagram/compare/output4/_users_search_Stub.js
@@ -1,0 +1,43 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+var assert = chai.assert;
+var request = require('request');
+
+describe('/users/search', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/MiniProfile"
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      request({
+        url: 'https://api.instagram.com/v1/users/search',
+        method: 'GET',
+        headers: {'Content-Type': 'application/json'}
+      },
+      function(error, response, body) {
+        if (error) {
+          done(error);
+          return;
+        }
+
+        assert.true(validator.validate(body, schema));
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output4/_users_self_feed_Stub.js
+++ b/test/instagram/compare/output4/_users_self_feed_Stub.js
@@ -1,0 +1,43 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+var assert = chai.assert;
+var request = require('request');
+
+describe('/users/self/feed', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Media"
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      request({
+        url: 'https://api.instagram.com/v1/users/self/feed',
+        method: 'GET',
+        headers: {'Content-Type': 'application/json'}
+      },
+      function(error, response, body) {
+        if (error) {
+          done(error);
+          return;
+        }
+
+        assert.true(validator.validate(body, schema));
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output4/_users_self_media_liked_Stub.js
+++ b/test/instagram/compare/output4/_users_self_media_liked_Stub.js
@@ -1,0 +1,43 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+var assert = chai.assert;
+var request = require('request');
+
+describe('/users/self/media/liked', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Media"
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      request({
+        url: 'https://api.instagram.com/v1/users/self/media/liked',
+        method: 'GET',
+        headers: {'Content-Type': 'application/json'}
+      },
+      function(error, response, body) {
+        if (error) {
+          done(error);
+          return;
+        }
+
+        assert.true(validator.validate(body, schema));
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output4/_users_self_requested-by_Stub.js
+++ b/test/instagram/compare/output4/_users_self_requested-by_Stub.js
@@ -1,0 +1,49 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+var assert = chai.assert;
+var request = require('request');
+
+describe('/users/self/requested-by', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "properties": {
+          "meta": {
+            "properties": {
+              "code": {
+                "type": "integer"
+              }
+            }
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/MiniProfile"
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      request({
+        url: 'https://api.instagram.com/v1/users/self/requested-by',
+        method: 'GET',
+        headers: {'Content-Type': 'application/json'}
+      },
+      function(error, response, body) {
+        if (error) {
+          done(error);
+          return;
+        }
+
+        assert.true(validator.validate(body, schema));
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output4/_users_{user-id}_Stub.js
+++ b/test/instagram/compare/output4/_users_{user-id}_Stub.js
@@ -1,0 +1,40 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+var assert = chai.assert;
+var request = require('request');
+
+describe('/users/{user-id}', function() {
+  describe('get', function() {
+    it('should respond with 200 The user object', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "properties": {
+          "data": {
+            "$ref": "#/definitions/User"
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      request({
+        url: 'https://api.instagram.com/v1/users/{user-id}',
+        method: 'GET',
+        headers: {'Content-Type': 'application/json'}
+      },
+      function(error, response, body) {
+        if (error) {
+          done(error);
+          return;
+        }
+
+        assert.true(validator.validate(body, schema));
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output4/_users_{user-id}_followed-by_Stub.js
+++ b/test/instagram/compare/output4/_users_{user-id}_followed-by_Stub.js
@@ -1,0 +1,42 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+var assert = chai.assert;
+var request = require('request');
+
+describe('/users/{user-id}/followed-by', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/MiniProfile"
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      request({
+        url: 'https://api.instagram.com/v1/users/{user-id}/followed-by',
+        method: 'GET',
+        headers: {'Content-Type': 'application/json'}
+      },
+      function(error, response, body) {
+        if (error) {
+          done(error);
+          return;
+        }
+
+        assert.true(validator.validate(body, schema));
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output4/_users_{user-id}_follows_Stub.js
+++ b/test/instagram/compare/output4/_users_{user-id}_follows_Stub.js
@@ -1,0 +1,42 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+var assert = chai.assert;
+var request = require('request');
+
+describe('/users/{user-id}/follows', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/MiniProfile"
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      request({
+        url: 'https://api.instagram.com/v1/users/{user-id}/follows',
+        method: 'GET',
+        headers: {'Content-Type': 'application/json'}
+      },
+      function(error, response, body) {
+        if (error) {
+          done(error);
+          return;
+        }
+
+        assert.true(validator.validate(body, schema));
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output4/_users_{user-id}_media_recent_Stub.js
+++ b/test/instagram/compare/output4/_users_{user-id}_media_recent_Stub.js
@@ -1,0 +1,46 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+var assert = chai.assert;
+var request = require('request');
+
+describe('/users/{user-id}/media/recent', function() {
+  describe('get', function() {
+    it('should respond with 200 Get the most recent media published by a user. To get the most recent
+media published by the owner of the access token, you can use `self`
+instead of the `user-id`.
+', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Media"
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      request({
+        url: 'https://api.instagram.com/v1/users/{user-id}/media/recent',
+        method: 'GET',
+        headers: {'Content-Type': 'application/json'}
+      },
+      function(error, response, body) {
+        if (error) {
+          done(error);
+          return;
+        }
+
+        assert.true(validator.validate(body, schema));
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output4/_users_{user-id}_relationship_Stub.js
+++ b/test/instagram/compare/output4/_users_{user-id}_relationship_Stub.js
@@ -1,0 +1,45 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+var assert = chai.assert;
+var request = require('request');
+
+describe('/users/{user-id}/relationship', function() {
+  describe('post', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/MiniProfile"
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      request({
+        url: 'https://api.instagram.com/v1/users/{user-id}/relationship',
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        json: {
+          action: 'DATA GOES HERE'
+        }
+      },
+      function(error, res, body) {
+        if (error) {
+          done(error);
+          return;
+        }
+
+        assert.true(validator.validate(body, schema));
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output5/_geographies_{geo-id}_media_recent_Stub.js
+++ b/test/instagram/compare/output5/_geographies_{geo-id}_media_recent_Stub.js
@@ -1,0 +1,28 @@
+'use strict';
+var chai = require('chai');
+
+chai.should();
+var supertest = require('supertest');
+var api = supertest('https://api.instagram.com'); // supertest init;
+
+describe('/geographies/{geo-id}/media/recent', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+
+      api.get('/v1/geographies/{geo-id}/media/recent')
+      .set('Accept', 'application/json')
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          done(err);
+          return;
+        }
+
+        res.should.equal(null);
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output5/_locations_search_Stub.js
+++ b/test/instagram/compare/output5/_locations_search_Stub.js
@@ -1,0 +1,44 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+
+chai.should();
+var supertest = require('supertest');
+var api = supertest('https://api.instagram.com'); // supertest init;
+
+describe('/locations/search', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Location"
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      api.get('/v1/locations/search')
+      .set('Accept', 'application/json')
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          done(err);
+          return;
+        }
+
+        validator.validate(res, schema).should.be.true;
+
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output5/_locations_{location-id}_Stub.js
+++ b/test/instagram/compare/output5/_locations_{location-id}_Stub.js
@@ -1,0 +1,41 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+
+chai.should();
+var supertest = require('supertest');
+var api = supertest('https://api.instagram.com'); // supertest init;
+
+describe('/locations/{location-id}', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "properties": {
+          "data": {
+            "$ref": "#/definitions/Location"
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      api.get('/v1/locations/{location-id}')
+      .set('Accept', 'application/json')
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          done(err);
+          return;
+        }
+
+        validator.validate(res, schema).should.be.true;
+
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output5/_locations_{location-id}_media_recent_Stub.js
+++ b/test/instagram/compare/output5/_locations_{location-id}_media_recent_Stub.js
@@ -1,0 +1,44 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+
+chai.should();
+var supertest = require('supertest');
+var api = supertest('https://api.instagram.com'); // supertest init;
+
+describe('/locations/{location-id}/media/recent', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Media"
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      api.get('/v1/locations/{location-id}/media/recent')
+      .set('Accept', 'application/json')
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          done(err);
+          return;
+        }
+
+        validator.validate(res, schema).should.be.true;
+
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output5/_media1_{shortcode}_Stub.js
+++ b/test/instagram/compare/output5/_media1_{shortcode}_Stub.js
@@ -1,0 +1,36 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+
+chai.should();
+var supertest = require('supertest');
+var api = supertest('https://api.instagram.com'); // supertest init;
+
+describe('/media1/{shortcode}', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "$ref": "#/definitions/Media"
+      };
+      /*eslint-enable*/
+
+      api.get('/v1/media1/{shortcode}')
+      .set('Accept', 'application/json')
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          done(err);
+          return;
+        }
+
+        validator.validate(res, schema).should.be.true;
+
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output5/_media_popular_Stub.js
+++ b/test/instagram/compare/output5/_media_popular_Stub.js
@@ -1,0 +1,44 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+
+chai.should();
+var supertest = require('supertest');
+var api = supertest('https://api.instagram.com'); // supertest init;
+
+describe('/media/popular', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Media"
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      api.get('/v1/media/popular')
+      .set('Accept', 'application/json')
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          done(err);
+          return;
+        }
+
+        validator.validate(res, schema).should.be.true;
+
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output5/_media_search_Stub.js
+++ b/test/instagram/compare/output5/_media_search_Stub.js
@@ -1,0 +1,56 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+
+chai.should();
+var supertest = require('supertest');
+var api = supertest('https://api.instagram.com'); // supertest init;
+
+describe('/media/search', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "description": "List of all media with added `distance` property",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "allOf": [
+                {
+                  "$ref": "#/definitions/Media"
+                },
+                {
+                  "properties": {
+                    "distance": {
+                      "type": "number"
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      api.get('/v1/media/search')
+      .set('Accept', 'application/json')
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          done(err);
+          return;
+        }
+
+        validator.validate(res, schema).should.be.true;
+
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output5/_media_{media-id}_Stub.js
+++ b/test/instagram/compare/output5/_media_{media-id}_Stub.js
@@ -1,0 +1,36 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+
+chai.should();
+var supertest = require('supertest');
+var api = supertest('https://api.instagram.com'); // supertest init;
+
+describe('/media/{media-id}', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "$ref": "#/definitions/Media"
+      };
+      /*eslint-enable*/
+
+      api.get('/v1/media/{media-id}')
+      .set('Accept', 'application/json')
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          done(err);
+          return;
+        }
+
+        validator.validate(res, schema).should.be.true;
+
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output5/_media_{media-id}_comments_Stub.js
+++ b/test/instagram/compare/output5/_media_{media-id}_comments_Stub.js
@@ -1,0 +1,90 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+
+chai.should();
+var supertest = require('supertest');
+var api = supertest('https://api.instagram.com'); // supertest init;
+
+describe('/media/{media-id}/comments', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "properties": {
+          "meta": {
+            "properties": {
+              "code": {
+                "type": "number"
+              }
+            }
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Comment"
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      api.get('/v1/media/{media-id}/comments')
+      .set('Accept', 'application/json')
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          done(err);
+          return;
+        }
+
+        validator.validate(res, schema).should.be.true;
+
+        done();
+      });
+    });
+
+  });
+
+  describe('post', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "properties": {
+          "meta": {
+            "properties": {
+              "code": {
+                "type": "number"
+              }
+            }
+          },
+          "data": {
+            "type": "object"
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      api.post('/v1/media/{media-id}/comments')
+      .set('Accept', 'application/json')
+      .send({
+        TEXT: 'DATA GOES HERE'
+      })
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          done(err);
+          return;
+        }
+
+        validator.validate(res, schema).should.be.true;
+
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output5/_media_{media-id}_likes_Stub.js
+++ b/test/instagram/compare/output5/_media_{media-id}_likes_Stub.js
@@ -1,0 +1,89 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+
+chai.should();
+var supertest = require('supertest');
+var api = supertest('https://api.instagram.com'); // supertest init;
+
+describe('/media/{media-id}/likes', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "properties": {
+          "meta": {
+            "properties": {
+              "code": {
+                "type": "number"
+              }
+            }
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Like"
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      api.get('/v1/media/{media-id}/likes')
+      .set('Accept', 'application/json')
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          done(err);
+          return;
+        }
+
+        validator.validate(res, schema).should.be.true;
+
+        done();
+      });
+    });
+
+  });
+
+  describe('post', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "properties": {
+          "meta": {
+            "properties": {
+              "code": {
+                "type": "number"
+              }
+            }
+          },
+          "data": {
+            "type": "object"
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      api.post('/v1/media/{media-id}/likes')
+      .set('Accept', 'application/json')
+      .send({
+      })
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          done(err);
+          return;
+        }
+
+        validator.validate(res, schema).should.be.true;
+
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output5/_tags_search_Stub.js
+++ b/test/instagram/compare/output5/_tags_search_Stub.js
@@ -1,0 +1,51 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+
+chai.should();
+var supertest = require('supertest');
+var api = supertest('https://api.instagram.com'); // supertest init;
+
+describe('/tags/search', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "properties": {
+          "meta": {
+            "properties": {
+              "code": {
+                "type": "integer"
+              }
+            }
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Tag"
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      api.get('/v1/tags/search')
+      .set('Accept', 'application/json')
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          done(err);
+          return;
+        }
+
+        validator.validate(res, schema).should.be.true;
+
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output5/_tags_{tag-name}_Stub.js
+++ b/test/instagram/compare/output5/_tags_{tag-name}_Stub.js
@@ -1,0 +1,36 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+
+chai.should();
+var supertest = require('supertest');
+var api = supertest('https://api.instagram.com'); // supertest init;
+
+describe('/tags/{tag-name}', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "$ref": "#/definitions/Tag"
+      };
+      /*eslint-enable*/
+
+      api.get('/v1/tags/{tag-name}')
+      .set('Accept', 'application/json')
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          done(err);
+          return;
+        }
+
+        validator.validate(res, schema).should.be.true;
+
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output5/_tags_{tag-name}_media_recent_Stub.js
+++ b/test/instagram/compare/output5/_tags_{tag-name}_media_recent_Stub.js
@@ -1,0 +1,43 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+
+chai.should();
+var supertest = require('supertest');
+var api = supertest('https://api.instagram.com'); // supertest init;
+
+describe('/tags/{tag-name}/media/recent', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Tag"
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      api.get('/v1/tags/{tag-name}/media/recent')
+      .set('Accept', 'application/json')
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          done(err);
+          return;
+        }
+
+        validator.validate(res, schema).should.be.true;
+
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output5/_users_search_Stub.js
+++ b/test/instagram/compare/output5/_users_search_Stub.js
@@ -1,0 +1,44 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+
+chai.should();
+var supertest = require('supertest');
+var api = supertest('https://api.instagram.com'); // supertest init;
+
+describe('/users/search', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/MiniProfile"
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      api.get('/v1/users/search')
+      .set('Accept', 'application/json')
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          done(err);
+          return;
+        }
+
+        validator.validate(res, schema).should.be.true;
+
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output5/_users_self_feed_Stub.js
+++ b/test/instagram/compare/output5/_users_self_feed_Stub.js
@@ -1,0 +1,44 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+
+chai.should();
+var supertest = require('supertest');
+var api = supertest('https://api.instagram.com'); // supertest init;
+
+describe('/users/self/feed', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Media"
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      api.get('/v1/users/self/feed')
+      .set('Accept', 'application/json')
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          done(err);
+          return;
+        }
+
+        validator.validate(res, schema).should.be.true;
+
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output5/_users_self_media_liked_Stub.js
+++ b/test/instagram/compare/output5/_users_self_media_liked_Stub.js
@@ -1,0 +1,44 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+
+chai.should();
+var supertest = require('supertest');
+var api = supertest('https://api.instagram.com'); // supertest init;
+
+describe('/users/self/media/liked', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Media"
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      api.get('/v1/users/self/media/liked')
+      .set('Accept', 'application/json')
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          done(err);
+          return;
+        }
+
+        validator.validate(res, schema).should.be.true;
+
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output5/_users_self_requested-by_Stub.js
+++ b/test/instagram/compare/output5/_users_self_requested-by_Stub.js
@@ -1,0 +1,50 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+
+chai.should();
+var supertest = require('supertest');
+var api = supertest('https://api.instagram.com'); // supertest init;
+
+describe('/users/self/requested-by', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "properties": {
+          "meta": {
+            "properties": {
+              "code": {
+                "type": "integer"
+              }
+            }
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/MiniProfile"
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      api.get('/v1/users/self/requested-by')
+      .set('Accept', 'application/json')
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          done(err);
+          return;
+        }
+
+        validator.validate(res, schema).should.be.true;
+
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output5/_users_{user-id}_Stub.js
+++ b/test/instagram/compare/output5/_users_{user-id}_Stub.js
@@ -1,0 +1,41 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+
+chai.should();
+var supertest = require('supertest');
+var api = supertest('https://api.instagram.com'); // supertest init;
+
+describe('/users/{user-id}', function() {
+  describe('get', function() {
+    it('should respond with 200 The user object', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "properties": {
+          "data": {
+            "$ref": "#/definitions/User"
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      api.get('/v1/users/{user-id}')
+      .set('Accept', 'application/json')
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          done(err);
+          return;
+        }
+
+        validator.validate(res, schema).should.be.true;
+
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output5/_users_{user-id}_followed-by_Stub.js
+++ b/test/instagram/compare/output5/_users_{user-id}_followed-by_Stub.js
@@ -1,0 +1,43 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+
+chai.should();
+var supertest = require('supertest');
+var api = supertest('https://api.instagram.com'); // supertest init;
+
+describe('/users/{user-id}/followed-by', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/MiniProfile"
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      api.get('/v1/users/{user-id}/followed-by')
+      .set('Accept', 'application/json')
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          done(err);
+          return;
+        }
+
+        validator.validate(res, schema).should.be.true;
+
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output5/_users_{user-id}_follows_Stub.js
+++ b/test/instagram/compare/output5/_users_{user-id}_follows_Stub.js
@@ -1,0 +1,43 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+
+chai.should();
+var supertest = require('supertest');
+var api = supertest('https://api.instagram.com'); // supertest init;
+
+describe('/users/{user-id}/follows', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/MiniProfile"
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      api.get('/v1/users/{user-id}/follows')
+      .set('Accept', 'application/json')
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          done(err);
+          return;
+        }
+
+        validator.validate(res, schema).should.be.true;
+
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output5/_users_{user-id}_media_recent_Stub.js
+++ b/test/instagram/compare/output5/_users_{user-id}_media_recent_Stub.js
@@ -1,0 +1,47 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+
+chai.should();
+var supertest = require('supertest');
+var api = supertest('https://api.instagram.com'); // supertest init;
+
+describe('/users/{user-id}/media/recent', function() {
+  describe('get', function() {
+    it('should respond with 200 Get the most recent media published by a user. To get the most recent
+media published by the owner of the access token, you can use `self`
+instead of the `user-id`.
+', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Media"
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      api.get('/v1/users/{user-id}/media/recent')
+      .set('Accept', 'application/json')
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          done(err);
+          return;
+        }
+
+        validator.validate(res, schema).should.be.true;
+
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output5/_users_{user-id}_relationship_Stub.js
+++ b/test/instagram/compare/output5/_users_{user-id}_relationship_Stub.js
@@ -1,0 +1,46 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+
+chai.should();
+var supertest = require('supertest');
+var api = supertest('https://api.instagram.com'); // supertest init;
+
+describe('/users/{user-id}/relationship', function() {
+  describe('post', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/MiniProfile"
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      api.post('/v1/users/{user-id}/relationship')
+      .set('Accept', 'application/json')
+      .send({
+        action: 'DATA GOES HERE'
+      })
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          done(err);
+          return;
+        }
+
+        validator.validate(res, schema).should.be.true;
+
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output6/_users_self_feed_Stub.js
+++ b/test/instagram/compare/output6/_users_self_feed_Stub.js
@@ -1,0 +1,44 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+
+chai.should();
+var supertest = require('supertest');
+var api = supertest('https://api.instagram.com'); // supertest init;
+
+describe('/users/self/feed', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Media"
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      api.get('/v1/users/self/feed')
+      .set('Accept', 'application/json')
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          done(err);
+          return;
+        }
+
+        validator.validate(res, schema).should.be.true;
+
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output6/_users_self_requested-by_Stub.js
+++ b/test/instagram/compare/output6/_users_self_requested-by_Stub.js
@@ -1,0 +1,50 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+
+chai.should();
+var supertest = require('supertest');
+var api = supertest('https://api.instagram.com'); // supertest init;
+
+describe('/users/self/requested-by', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "properties": {
+          "meta": {
+            "properties": {
+              "code": {
+                "type": "integer"
+              }
+            }
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/MiniProfile"
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      api.get('/v1/users/self/requested-by')
+      .set('Accept', 'application/json')
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          done(err);
+          return;
+        }
+
+        validator.validate(res, schema).should.be.true;
+
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output6/_users_{user-id}_Stub.js
+++ b/test/instagram/compare/output6/_users_{user-id}_Stub.js
@@ -1,0 +1,41 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+
+chai.should();
+var supertest = require('supertest');
+var api = supertest('https://api.instagram.com'); // supertest init;
+
+describe('/users/{user-id}', function() {
+  describe('get', function() {
+    it('should respond with 200 The user object', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "properties": {
+          "data": {
+            "$ref": "#/definitions/User"
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      api.get('/v1/users/{user-id}')
+      .set('Accept', 'application/json')
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          done(err);
+          return;
+        }
+
+        validator.validate(res, schema).should.be.true;
+
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output7/_geographies_{geo-id}_media_recent_Stub.js
+++ b/test/instagram/compare/output7/_geographies_{geo-id}_media_recent_Stub.js
@@ -1,0 +1,27 @@
+'use strict';
+var chai = require('chai');
+var expect = chai.expect;
+var supertest = require('supertest');
+var api = supertest('https://api.instagram.com'); // supertest init;
+
+describe('/geographies/{geo-id}/media/recent', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+
+      api.get('/v1/geographies/{geo-id}/media/recent')
+      .set('Accept', 'application/json')
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          done(err);
+          return;
+        }
+
+        expect(res).to.equal(null);
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output7/_locations_search_Stub.js
+++ b/test/instagram/compare/output7/_locations_search_Stub.js
@@ -1,0 +1,43 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+var expect = chai.expect;
+var supertest = require('supertest');
+var api = supertest('https://api.instagram.com'); // supertest init;
+
+describe('/locations/search', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Location"
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      api.get('/v1/locations/search')
+      .set('Accept', 'application/json')
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          done(err);
+          return;
+        }
+
+        expect(validator.validate(res, schema)).to.be.true;
+
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output7/_locations_{location-id}_Stub.js
+++ b/test/instagram/compare/output7/_locations_{location-id}_Stub.js
@@ -1,0 +1,40 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+var expect = chai.expect;
+var supertest = require('supertest');
+var api = supertest('https://api.instagram.com'); // supertest init;
+
+describe('/locations/{location-id}', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "properties": {
+          "data": {
+            "$ref": "#/definitions/Location"
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      api.get('/v1/locations/{location-id}')
+      .set('Accept', 'application/json')
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          done(err);
+          return;
+        }
+
+        expect(validator.validate(res, schema)).to.be.true;
+
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output7/_locations_{location-id}_media_recent_Stub.js
+++ b/test/instagram/compare/output7/_locations_{location-id}_media_recent_Stub.js
@@ -1,0 +1,43 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+var expect = chai.expect;
+var supertest = require('supertest');
+var api = supertest('https://api.instagram.com'); // supertest init;
+
+describe('/locations/{location-id}/media/recent', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Media"
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      api.get('/v1/locations/{location-id}/media/recent')
+      .set('Accept', 'application/json')
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          done(err);
+          return;
+        }
+
+        expect(validator.validate(res, schema)).to.be.true;
+
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output7/_media1_{shortcode}_Stub.js
+++ b/test/instagram/compare/output7/_media1_{shortcode}_Stub.js
@@ -1,0 +1,35 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+var expect = chai.expect;
+var supertest = require('supertest');
+var api = supertest('https://api.instagram.com'); // supertest init;
+
+describe('/media1/{shortcode}', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "$ref": "#/definitions/Media"
+      };
+      /*eslint-enable*/
+
+      api.get('/v1/media1/{shortcode}')
+      .set('Accept', 'application/json')
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          done(err);
+          return;
+        }
+
+        expect(validator.validate(res, schema)).to.be.true;
+
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output7/_media_popular_Stub.js
+++ b/test/instagram/compare/output7/_media_popular_Stub.js
@@ -1,0 +1,43 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+var expect = chai.expect;
+var supertest = require('supertest');
+var api = supertest('https://api.instagram.com'); // supertest init;
+
+describe('/media/popular', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Media"
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      api.get('/v1/media/popular')
+      .set('Accept', 'application/json')
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          done(err);
+          return;
+        }
+
+        expect(validator.validate(res, schema)).to.be.true;
+
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output7/_media_search_Stub.js
+++ b/test/instagram/compare/output7/_media_search_Stub.js
@@ -1,0 +1,55 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+var expect = chai.expect;
+var supertest = require('supertest');
+var api = supertest('https://api.instagram.com'); // supertest init;
+
+describe('/media/search', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "description": "List of all media with added `distance` property",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "allOf": [
+                {
+                  "$ref": "#/definitions/Media"
+                },
+                {
+                  "properties": {
+                    "distance": {
+                      "type": "number"
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      api.get('/v1/media/search')
+      .set('Accept', 'application/json')
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          done(err);
+          return;
+        }
+
+        expect(validator.validate(res, schema)).to.be.true;
+
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output7/_media_{media-id}_Stub.js
+++ b/test/instagram/compare/output7/_media_{media-id}_Stub.js
@@ -1,0 +1,35 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+var expect = chai.expect;
+var supertest = require('supertest');
+var api = supertest('https://api.instagram.com'); // supertest init;
+
+describe('/media/{media-id}', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "$ref": "#/definitions/Media"
+      };
+      /*eslint-enable*/
+
+      api.get('/v1/media/{media-id}')
+      .set('Accept', 'application/json')
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          done(err);
+          return;
+        }
+
+        expect(validator.validate(res, schema)).to.be.true;
+
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output7/_media_{media-id}_comments_Stub.js
+++ b/test/instagram/compare/output7/_media_{media-id}_comments_Stub.js
@@ -1,0 +1,89 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+var expect = chai.expect;
+var supertest = require('supertest');
+var api = supertest('https://api.instagram.com'); // supertest init;
+
+describe('/media/{media-id}/comments', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "properties": {
+          "meta": {
+            "properties": {
+              "code": {
+                "type": "number"
+              }
+            }
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Comment"
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      api.get('/v1/media/{media-id}/comments')
+      .set('Accept', 'application/json')
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          done(err);
+          return;
+        }
+
+        expect(validator.validate(res, schema)).to.be.true;
+
+        done();
+      });
+    });
+
+  });
+
+  describe('post', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "properties": {
+          "meta": {
+            "properties": {
+              "code": {
+                "type": "number"
+              }
+            }
+          },
+          "data": {
+            "type": "object"
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      api.post('/v1/media/{media-id}/comments')
+      .set('Accept', 'application/json')
+      .send({
+        TEXT: 'DATA GOES HERE'
+      })
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          done(err);
+          return;
+        }
+
+        expect(validator.validate(res, schema)).to.be.true;
+
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output7/_media_{media-id}_likes_Stub.js
+++ b/test/instagram/compare/output7/_media_{media-id}_likes_Stub.js
@@ -1,0 +1,88 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+var expect = chai.expect;
+var supertest = require('supertest');
+var api = supertest('https://api.instagram.com'); // supertest init;
+
+describe('/media/{media-id}/likes', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "properties": {
+          "meta": {
+            "properties": {
+              "code": {
+                "type": "number"
+              }
+            }
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Like"
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      api.get('/v1/media/{media-id}/likes')
+      .set('Accept', 'application/json')
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          done(err);
+          return;
+        }
+
+        expect(validator.validate(res, schema)).to.be.true;
+
+        done();
+      });
+    });
+
+  });
+
+  describe('post', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "properties": {
+          "meta": {
+            "properties": {
+              "code": {
+                "type": "number"
+              }
+            }
+          },
+          "data": {
+            "type": "object"
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      api.post('/v1/media/{media-id}/likes')
+      .set('Accept', 'application/json')
+      .send({
+      })
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          done(err);
+          return;
+        }
+
+        expect(validator.validate(res, schema)).to.be.true;
+
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output7/_tags_search_Stub.js
+++ b/test/instagram/compare/output7/_tags_search_Stub.js
@@ -1,0 +1,50 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+var expect = chai.expect;
+var supertest = require('supertest');
+var api = supertest('https://api.instagram.com'); // supertest init;
+
+describe('/tags/search', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "properties": {
+          "meta": {
+            "properties": {
+              "code": {
+                "type": "integer"
+              }
+            }
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Tag"
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      api.get('/v1/tags/search')
+      .set('Accept', 'application/json')
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          done(err);
+          return;
+        }
+
+        expect(validator.validate(res, schema)).to.be.true;
+
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output7/_tags_{tag-name}_Stub.js
+++ b/test/instagram/compare/output7/_tags_{tag-name}_Stub.js
@@ -1,0 +1,35 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+var expect = chai.expect;
+var supertest = require('supertest');
+var api = supertest('https://api.instagram.com'); // supertest init;
+
+describe('/tags/{tag-name}', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "$ref": "#/definitions/Tag"
+      };
+      /*eslint-enable*/
+
+      api.get('/v1/tags/{tag-name}')
+      .set('Accept', 'application/json')
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          done(err);
+          return;
+        }
+
+        expect(validator.validate(res, schema)).to.be.true;
+
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output7/_tags_{tag-name}_media_recent_Stub.js
+++ b/test/instagram/compare/output7/_tags_{tag-name}_media_recent_Stub.js
@@ -1,0 +1,42 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+var expect = chai.expect;
+var supertest = require('supertest');
+var api = supertest('https://api.instagram.com'); // supertest init;
+
+describe('/tags/{tag-name}/media/recent', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Tag"
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      api.get('/v1/tags/{tag-name}/media/recent')
+      .set('Accept', 'application/json')
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          done(err);
+          return;
+        }
+
+        expect(validator.validate(res, schema)).to.be.true;
+
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output7/_users_search_Stub.js
+++ b/test/instagram/compare/output7/_users_search_Stub.js
@@ -1,0 +1,43 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+var expect = chai.expect;
+var supertest = require('supertest');
+var api = supertest('https://api.instagram.com'); // supertest init;
+
+describe('/users/search', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/MiniProfile"
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      api.get('/v1/users/search')
+      .set('Accept', 'application/json')
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          done(err);
+          return;
+        }
+
+        expect(validator.validate(res, schema)).to.be.true;
+
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output7/_users_self_feed_Stub.js
+++ b/test/instagram/compare/output7/_users_self_feed_Stub.js
@@ -1,0 +1,43 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+var expect = chai.expect;
+var supertest = require('supertest');
+var api = supertest('https://api.instagram.com'); // supertest init;
+
+describe('/users/self/feed', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Media"
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      api.get('/v1/users/self/feed')
+      .set('Accept', 'application/json')
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          done(err);
+          return;
+        }
+
+        expect(validator.validate(res, schema)).to.be.true;
+
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output7/_users_self_media_liked_Stub.js
+++ b/test/instagram/compare/output7/_users_self_media_liked_Stub.js
@@ -1,0 +1,43 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+var expect = chai.expect;
+var supertest = require('supertest');
+var api = supertest('https://api.instagram.com'); // supertest init;
+
+describe('/users/self/media/liked', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Media"
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      api.get('/v1/users/self/media/liked')
+      .set('Accept', 'application/json')
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          done(err);
+          return;
+        }
+
+        expect(validator.validate(res, schema)).to.be.true;
+
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output7/_users_self_requested-by_Stub.js
+++ b/test/instagram/compare/output7/_users_self_requested-by_Stub.js
@@ -1,0 +1,49 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+var expect = chai.expect;
+var supertest = require('supertest');
+var api = supertest('https://api.instagram.com'); // supertest init;
+
+describe('/users/self/requested-by', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "properties": {
+          "meta": {
+            "properties": {
+              "code": {
+                "type": "integer"
+              }
+            }
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/MiniProfile"
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      api.get('/v1/users/self/requested-by')
+      .set('Accept', 'application/json')
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          done(err);
+          return;
+        }
+
+        expect(validator.validate(res, schema)).to.be.true;
+
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output7/_users_{user-id}_Stub.js
+++ b/test/instagram/compare/output7/_users_{user-id}_Stub.js
@@ -1,0 +1,40 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+var expect = chai.expect;
+var supertest = require('supertest');
+var api = supertest('https://api.instagram.com'); // supertest init;
+
+describe('/users/{user-id}', function() {
+  describe('get', function() {
+    it('should respond with 200 The user object', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "properties": {
+          "data": {
+            "$ref": "#/definitions/User"
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      api.get('/v1/users/{user-id}')
+      .set('Accept', 'application/json')
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          done(err);
+          return;
+        }
+
+        expect(validator.validate(res, schema)).to.be.true;
+
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output7/_users_{user-id}_followed-by_Stub.js
+++ b/test/instagram/compare/output7/_users_{user-id}_followed-by_Stub.js
@@ -1,0 +1,42 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+var expect = chai.expect;
+var supertest = require('supertest');
+var api = supertest('https://api.instagram.com'); // supertest init;
+
+describe('/users/{user-id}/followed-by', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/MiniProfile"
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      api.get('/v1/users/{user-id}/followed-by')
+      .set('Accept', 'application/json')
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          done(err);
+          return;
+        }
+
+        expect(validator.validate(res, schema)).to.be.true;
+
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output7/_users_{user-id}_follows_Stub.js
+++ b/test/instagram/compare/output7/_users_{user-id}_follows_Stub.js
@@ -1,0 +1,42 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+var expect = chai.expect;
+var supertest = require('supertest');
+var api = supertest('https://api.instagram.com'); // supertest init;
+
+describe('/users/{user-id}/follows', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/MiniProfile"
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      api.get('/v1/users/{user-id}/follows')
+      .set('Accept', 'application/json')
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          done(err);
+          return;
+        }
+
+        expect(validator.validate(res, schema)).to.be.true;
+
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output7/_users_{user-id}_media_recent_Stub.js
+++ b/test/instagram/compare/output7/_users_{user-id}_media_recent_Stub.js
@@ -1,0 +1,46 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+var expect = chai.expect;
+var supertest = require('supertest');
+var api = supertest('https://api.instagram.com'); // supertest init;
+
+describe('/users/{user-id}/media/recent', function() {
+  describe('get', function() {
+    it('should respond with 200 Get the most recent media published by a user. To get the most recent
+media published by the owner of the access token, you can use `self`
+instead of the `user-id`.
+', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Media"
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      api.get('/v1/users/{user-id}/media/recent')
+      .set('Accept', 'application/json')
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          done(err);
+          return;
+        }
+
+        expect(validator.validate(res, schema)).to.be.true;
+
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output7/_users_{user-id}_relationship_Stub.js
+++ b/test/instagram/compare/output7/_users_{user-id}_relationship_Stub.js
@@ -1,0 +1,45 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+var expect = chai.expect;
+var supertest = require('supertest');
+var api = supertest('https://api.instagram.com'); // supertest init;
+
+describe('/users/{user-id}/relationship', function() {
+  describe('post', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/MiniProfile"
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      api.post('/v1/users/{user-id}/relationship')
+      .set('Accept', 'application/json')
+      .send({
+        action: 'DATA GOES HERE'
+      })
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          done(err);
+          return;
+        }
+
+        expect(validator.validate(res, schema)).to.be.true;
+
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output8/_geographies_{geo-id}_media_recent_Stub.js
+++ b/test/instagram/compare/output8/_geographies_{geo-id}_media_recent_Stub.js
@@ -1,0 +1,27 @@
+'use strict';
+var chai = require('chai');
+var assert = chai.assert;
+var supertest = require('supertest');
+var api = supertest('https://api.instagram.com'); // supertest init;
+
+describe('/geographies/{geo-id}/media/recent', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+
+      api.get('/v1/geographies/{geo-id}/media/recent')
+      .set('Accept', 'application/json')
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          done(err);
+          return;
+        }
+
+        assert.isNull(res);
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output8/_locations_search_Stub.js
+++ b/test/instagram/compare/output8/_locations_search_Stub.js
@@ -1,0 +1,42 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+var assert = chai.assert;
+var supertest = require('supertest');
+var api = supertest('https://api.instagram.com'); // supertest init;
+
+describe('/locations/search', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Location"
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      api.get('/v1/locations/search')
+      .set('Accept', 'application/json')
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          done(err);
+          return;
+        }
+
+        assert.true(validator.validate(res, schema));
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output8/_locations_{location-id}_Stub.js
+++ b/test/instagram/compare/output8/_locations_{location-id}_Stub.js
@@ -1,0 +1,39 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+var assert = chai.assert;
+var supertest = require('supertest');
+var api = supertest('https://api.instagram.com'); // supertest init;
+
+describe('/locations/{location-id}', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "properties": {
+          "data": {
+            "$ref": "#/definitions/Location"
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      api.get('/v1/locations/{location-id}')
+      .set('Accept', 'application/json')
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          done(err);
+          return;
+        }
+
+        assert.true(validator.validate(res, schema));
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output8/_locations_{location-id}_media_recent_Stub.js
+++ b/test/instagram/compare/output8/_locations_{location-id}_media_recent_Stub.js
@@ -1,0 +1,42 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+var assert = chai.assert;
+var supertest = require('supertest');
+var api = supertest('https://api.instagram.com'); // supertest init;
+
+describe('/locations/{location-id}/media/recent', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Media"
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      api.get('/v1/locations/{location-id}/media/recent')
+      .set('Accept', 'application/json')
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          done(err);
+          return;
+        }
+
+        assert.true(validator.validate(res, schema));
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output8/_media1_{shortcode}_Stub.js
+++ b/test/instagram/compare/output8/_media1_{shortcode}_Stub.js
@@ -1,0 +1,34 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+var assert = chai.assert;
+var supertest = require('supertest');
+var api = supertest('https://api.instagram.com'); // supertest init;
+
+describe('/media1/{shortcode}', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "$ref": "#/definitions/Media"
+      };
+      /*eslint-enable*/
+
+      api.get('/v1/media1/{shortcode}')
+      .set('Accept', 'application/json')
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          done(err);
+          return;
+        }
+
+        assert.true(validator.validate(res, schema));
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output8/_media_popular_Stub.js
+++ b/test/instagram/compare/output8/_media_popular_Stub.js
@@ -1,0 +1,42 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+var assert = chai.assert;
+var supertest = require('supertest');
+var api = supertest('https://api.instagram.com'); // supertest init;
+
+describe('/media/popular', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Media"
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      api.get('/v1/media/popular')
+      .set('Accept', 'application/json')
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          done(err);
+          return;
+        }
+
+        assert.true(validator.validate(res, schema));
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output8/_media_search_Stub.js
+++ b/test/instagram/compare/output8/_media_search_Stub.js
@@ -1,0 +1,54 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+var assert = chai.assert;
+var supertest = require('supertest');
+var api = supertest('https://api.instagram.com'); // supertest init;
+
+describe('/media/search', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "description": "List of all media with added `distance` property",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "allOf": [
+                {
+                  "$ref": "#/definitions/Media"
+                },
+                {
+                  "properties": {
+                    "distance": {
+                      "type": "number"
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      api.get('/v1/media/search')
+      .set('Accept', 'application/json')
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          done(err);
+          return;
+        }
+
+        assert.true(validator.validate(res, schema));
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output8/_media_{media-id}_Stub.js
+++ b/test/instagram/compare/output8/_media_{media-id}_Stub.js
@@ -1,0 +1,34 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+var assert = chai.assert;
+var supertest = require('supertest');
+var api = supertest('https://api.instagram.com'); // supertest init;
+
+describe('/media/{media-id}', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "$ref": "#/definitions/Media"
+      };
+      /*eslint-enable*/
+
+      api.get('/v1/media/{media-id}')
+      .set('Accept', 'application/json')
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          done(err);
+          return;
+        }
+
+        assert.true(validator.validate(res, schema));
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output8/_media_{media-id}_comments_Stub.js
+++ b/test/instagram/compare/output8/_media_{media-id}_comments_Stub.js
@@ -1,0 +1,87 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+var assert = chai.assert;
+var supertest = require('supertest');
+var api = supertest('https://api.instagram.com'); // supertest init;
+
+describe('/media/{media-id}/comments', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "properties": {
+          "meta": {
+            "properties": {
+              "code": {
+                "type": "number"
+              }
+            }
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Comment"
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      api.get('/v1/media/{media-id}/comments')
+      .set('Accept', 'application/json')
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          done(err);
+          return;
+        }
+
+        assert.true(validator.validate(res, schema));
+        done();
+      });
+    });
+
+  });
+
+  describe('post', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "properties": {
+          "meta": {
+            "properties": {
+              "code": {
+                "type": "number"
+              }
+            }
+          },
+          "data": {
+            "type": "object"
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      api.post('/v1/media/{media-id}/comments')
+      .set('Accept', 'application/json')
+      .send({
+        TEXT: 'DATA GOES HERE'
+      })
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          done(err);
+          return;
+        }
+
+        assert.true(validator.validate(res, schema));
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output8/_media_{media-id}_likes_Stub.js
+++ b/test/instagram/compare/output8/_media_{media-id}_likes_Stub.js
@@ -1,0 +1,86 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+var assert = chai.assert;
+var supertest = require('supertest');
+var api = supertest('https://api.instagram.com'); // supertest init;
+
+describe('/media/{media-id}/likes', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "properties": {
+          "meta": {
+            "properties": {
+              "code": {
+                "type": "number"
+              }
+            }
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Like"
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      api.get('/v1/media/{media-id}/likes')
+      .set('Accept', 'application/json')
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          done(err);
+          return;
+        }
+
+        assert.true(validator.validate(res, schema));
+        done();
+      });
+    });
+
+  });
+
+  describe('post', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "properties": {
+          "meta": {
+            "properties": {
+              "code": {
+                "type": "number"
+              }
+            }
+          },
+          "data": {
+            "type": "object"
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      api.post('/v1/media/{media-id}/likes')
+      .set('Accept', 'application/json')
+      .send({
+      })
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          done(err);
+          return;
+        }
+
+        assert.true(validator.validate(res, schema));
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output8/_tags_search_Stub.js
+++ b/test/instagram/compare/output8/_tags_search_Stub.js
@@ -1,0 +1,49 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+var assert = chai.assert;
+var supertest = require('supertest');
+var api = supertest('https://api.instagram.com'); // supertest init;
+
+describe('/tags/search', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "properties": {
+          "meta": {
+            "properties": {
+              "code": {
+                "type": "integer"
+              }
+            }
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Tag"
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      api.get('/v1/tags/search')
+      .set('Accept', 'application/json')
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          done(err);
+          return;
+        }
+
+        assert.true(validator.validate(res, schema));
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output8/_tags_{tag-name}_Stub.js
+++ b/test/instagram/compare/output8/_tags_{tag-name}_Stub.js
@@ -1,0 +1,34 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+var assert = chai.assert;
+var supertest = require('supertest');
+var api = supertest('https://api.instagram.com'); // supertest init;
+
+describe('/tags/{tag-name}', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "$ref": "#/definitions/Tag"
+      };
+      /*eslint-enable*/
+
+      api.get('/v1/tags/{tag-name}')
+      .set('Accept', 'application/json')
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          done(err);
+          return;
+        }
+
+        assert.true(validator.validate(res, schema));
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output8/_tags_{tag-name}_media_recent_Stub.js
+++ b/test/instagram/compare/output8/_tags_{tag-name}_media_recent_Stub.js
@@ -1,0 +1,41 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+var assert = chai.assert;
+var supertest = require('supertest');
+var api = supertest('https://api.instagram.com'); // supertest init;
+
+describe('/tags/{tag-name}/media/recent', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Tag"
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      api.get('/v1/tags/{tag-name}/media/recent')
+      .set('Accept', 'application/json')
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          done(err);
+          return;
+        }
+
+        assert.true(validator.validate(res, schema));
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output8/_users_search_Stub.js
+++ b/test/instagram/compare/output8/_users_search_Stub.js
@@ -1,0 +1,42 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+var assert = chai.assert;
+var supertest = require('supertest');
+var api = supertest('https://api.instagram.com'); // supertest init;
+
+describe('/users/search', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/MiniProfile"
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      api.get('/v1/users/search')
+      .set('Accept', 'application/json')
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          done(err);
+          return;
+        }
+
+        assert.true(validator.validate(res, schema));
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output8/_users_self_feed_Stub.js
+++ b/test/instagram/compare/output8/_users_self_feed_Stub.js
@@ -1,0 +1,42 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+var assert = chai.assert;
+var supertest = require('supertest');
+var api = supertest('https://api.instagram.com'); // supertest init;
+
+describe('/users/self/feed', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Media"
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      api.get('/v1/users/self/feed')
+      .set('Accept', 'application/json')
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          done(err);
+          return;
+        }
+
+        assert.true(validator.validate(res, schema));
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output8/_users_self_media_liked_Stub.js
+++ b/test/instagram/compare/output8/_users_self_media_liked_Stub.js
@@ -1,0 +1,42 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+var assert = chai.assert;
+var supertest = require('supertest');
+var api = supertest('https://api.instagram.com'); // supertest init;
+
+describe('/users/self/media/liked', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Media"
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      api.get('/v1/users/self/media/liked')
+      .set('Accept', 'application/json')
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          done(err);
+          return;
+        }
+
+        assert.true(validator.validate(res, schema));
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output8/_users_self_requested-by_Stub.js
+++ b/test/instagram/compare/output8/_users_self_requested-by_Stub.js
@@ -1,0 +1,48 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+var assert = chai.assert;
+var supertest = require('supertest');
+var api = supertest('https://api.instagram.com'); // supertest init;
+
+describe('/users/self/requested-by', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "properties": {
+          "meta": {
+            "properties": {
+              "code": {
+                "type": "integer"
+              }
+            }
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/MiniProfile"
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      api.get('/v1/users/self/requested-by')
+      .set('Accept', 'application/json')
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          done(err);
+          return;
+        }
+
+        assert.true(validator.validate(res, schema));
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output8/_users_{user-id}_Stub.js
+++ b/test/instagram/compare/output8/_users_{user-id}_Stub.js
@@ -1,0 +1,39 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+var assert = chai.assert;
+var supertest = require('supertest');
+var api = supertest('https://api.instagram.com'); // supertest init;
+
+describe('/users/{user-id}', function() {
+  describe('get', function() {
+    it('should respond with 200 The user object', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "properties": {
+          "data": {
+            "$ref": "#/definitions/User"
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      api.get('/v1/users/{user-id}')
+      .set('Accept', 'application/json')
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          done(err);
+          return;
+        }
+
+        assert.true(validator.validate(res, schema));
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output8/_users_{user-id}_followed-by_Stub.js
+++ b/test/instagram/compare/output8/_users_{user-id}_followed-by_Stub.js
@@ -1,0 +1,41 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+var assert = chai.assert;
+var supertest = require('supertest');
+var api = supertest('https://api.instagram.com'); // supertest init;
+
+describe('/users/{user-id}/followed-by', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/MiniProfile"
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      api.get('/v1/users/{user-id}/followed-by')
+      .set('Accept', 'application/json')
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          done(err);
+          return;
+        }
+
+        assert.true(validator.validate(res, schema));
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output8/_users_{user-id}_follows_Stub.js
+++ b/test/instagram/compare/output8/_users_{user-id}_follows_Stub.js
@@ -1,0 +1,41 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+var assert = chai.assert;
+var supertest = require('supertest');
+var api = supertest('https://api.instagram.com'); // supertest init;
+
+describe('/users/{user-id}/follows', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/MiniProfile"
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      api.get('/v1/users/{user-id}/follows')
+      .set('Accept', 'application/json')
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          done(err);
+          return;
+        }
+
+        assert.true(validator.validate(res, schema));
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output8/_users_{user-id}_media_recent_Stub.js
+++ b/test/instagram/compare/output8/_users_{user-id}_media_recent_Stub.js
@@ -1,0 +1,45 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+var assert = chai.assert;
+var supertest = require('supertest');
+var api = supertest('https://api.instagram.com'); // supertest init;
+
+describe('/users/{user-id}/media/recent', function() {
+  describe('get', function() {
+    it('should respond with 200 Get the most recent media published by a user. To get the most recent
+media published by the owner of the access token, you can use `self`
+instead of the `user-id`.
+', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Media"
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      api.get('/v1/users/{user-id}/media/recent')
+      .set('Accept', 'application/json')
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          done(err);
+          return;
+        }
+
+        assert.true(validator.validate(res, schema));
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/compare/output8/_users_{user-id}_relationship_Stub.js
+++ b/test/instagram/compare/output8/_users_{user-id}_relationship_Stub.js
@@ -1,0 +1,44 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+var assert = chai.assert;
+var supertest = require('supertest');
+var api = supertest('https://api.instagram.com'); // supertest init;
+
+describe('/users/{user-id}/relationship', function() {
+  describe('post', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/MiniProfile"
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+
+      api.post('/v1/users/{user-id}/relationship')
+      .set('Accept', 'application/json')
+      .send({
+        action: 'DATA GOES HERE'
+      })
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          done(err);
+          return;
+        }
+
+        assert.true(validator.validate(res, schema));
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instagram/swagger.json
+++ b/test/instagram/swagger.json
@@ -1,0 +1,1236 @@
+{
+    "swagger": "2.0",
+    "info": {
+        "version": "v1",
+        "title": "Instagram API",
+        "description": "The first version of the Instagram API is an exciting step forward towards\nmaking it easier for users to have open access to their data. We created it\nso that you can surface the amazing content Instagram users share every\nsecond, in fun and innovative ways.\n\nBuild something great!\n\nOnce you've\n[registered your client](http://instagram.com/developer/register/) it's easy\nto start requesting data from Instagram.\n\nAll endpoints are only accessible via https and are located at\n`api.instagram.com`. For instance: you can grab the most popular photos at\nthe moment by accessing the following URL with your client ID\n(replace CLIENT-ID with your own):\n```\n  https://api.instagram.com/v1/media/popular?client_id=CLIENT-ID\n```\nYou're best off using an access_token for the authenticated user for each\nendpoint, though many endpoints don't require it.\nIn some cases an access_token will give you more access to information, and\nin all cases, it means that you are operating under a per-access_token limit\nvs. the same limit for your single client_id.\n\n\n## Limits\nBe nice. If you're sending too many requests too quickly, we'll send back a\n`503` error code (server unavailable).\nYou are limited to 5000 requests per hour per `access_token` or `client_id`\noverall. Practically, this means you should (when possible) authenticate\nusers so that limits are well outside the reach of a given user.\n\n## Deleting Objects\nWe do our best to have all our URLs be\n[RESTful](http://en.wikipedia.org/wiki/Representational_state_transfer).\nEvery endpoint (URL) may support one of four different http verbs. GET\nrequests fetch information about an object, POST requests create objects,\nPUT requests update objects, and finally DELETE requests will delete\nobjects.\n\nSince many old browsers don't support PUT or DELETE, we've made it easy to\nfake PUTs and DELETEs. All you have to do is do a POST with _method=PUT or\n_method=DELETE as a parameter and we will treat it as if you used PUT or\nDELETE respectively.\n\n## Structure\n\n### The Envelope\nEvery response is contained by an envelope. That is, each response has a\npredictable set of keys with which you can expect to interact:\n```json\n{\n    \"meta\": {\n        \"code\": 200\n    },\n    \"data\": {\n        ...\n    },\n    \"pagination\": {\n        \"next_url\": \"...\",\n        \"next_max_id\": \"13872296\"\n    }\n}\n```\n\n#### META\nThe meta key is used to communicate extra information about the response to\nthe developer. If all goes well, you'll only ever see a code key with value\n200. However, sometimes things go wrong, and in that case you might see a\nresponse like:\n```json\n{\n    \"meta\": {\n        \"error_type\": \"OAuthException\",\n        \"code\": 400,\n        \"error_message\": \"...\"\n    }\n}\n```\n\n#### DATA\nThe data key is the meat of the response. It may be a list or dictionary,\nbut either way this is where you'll find the data you requested.\n#### PAGINATION\nSometimes you just can't get enough. For this reason, we've provided a\nconvenient way to access more data in any request for sequential data.\nSimply call the url in the next_url parameter and we'll respond with the\nnext set of data.\n```json\n{\n    ...\n    \"pagination\": {\n        \"next_url\": \"https://api.instagram.com/v1/tags/puppy/media/recent?access_token=fb2e77d.47a0479900504cb3ab4a1f626d174d2d&max_id=13872296\",\n        \"next_max_id\": \"13872296\"\n    }\n}\n```\nOn views where pagination is present, we also support the \"count\" parameter.\nSimply set this to the number of items you'd like to receive. Note that the\ndefault values should respond with fine for most applications - but if you decide to\nincrease this number there is a maximum value defined on each endpoint.\n\n### JSONP\nIf you're writing an AJAX application, and you'd like to wrap our response\nwith a callback, all you have to do is specify a callback parameter with\nany API call:\n```\nhttps://api.instagram.com/v1/tags/coffee/media/recent?access_token=fb2e77d.47a0479900504cb3ab4a1f626d174d2d&callback=callbackFunction\n```\nWould respond with:\n```js\ncallbackFunction({\n    ...\n});\n```\n",
+        "termsOfService": "http://instagram.com/about/legal/terms/api"
+    },
+    "host": "api.instagram.com",
+    "basePath": "/v1",
+    "schemes": [
+        "https"
+    ],
+    "produces": [
+        "application/json"
+    ],
+    "consumes": [
+        "application/json"
+    ],
+    "tags": [
+        {
+            "name": "Users"
+        },
+        {
+            "name": "Relationships",
+            "description": "Relationships are expressed using the following terms:\n\n**outgoing_status**: Your relationship to the user. Can be \"follows\",\n  \"requested\", \"none\".\n**incoming_status**: A user's relationship to you. Can be \"followed_by\",\n  \"requested_by\", \"blocked_by_you\", \"none\".\n"
+        },
+        {
+            "name": "Media",
+            "description": "At this time, uploading via the API is not possible. We made a conscious\nchoice not to add this for the following reasons:\n\n* Instagram is about your life on the go â€“ we hope to encourage photos\n  from within the app.\n* We want to fight spam & low quality photos. Once we allow uploading\n  from other sources, it's harder to control what comes into the Instagram\n  ecosystem. All this being said, we're working on ways to ensure users\n  have a consistent and high-quality experience on our platform.\n"
+        },
+        {
+            "name": "Commnts"
+        },
+        {
+            "name": "Likes"
+        },
+        {
+            "name": "Tags"
+        },
+        {
+            "name": "Location"
+        },
+        {
+            "name": "Subscribtions"
+        }
+    ],
+    "securityDefinitions": {
+        "oauth": {
+            "type": "oauth2",
+            "flow": "implicit",
+            "authorizationUrl": "https://instagram.com/oauth/authorize/?client_id=CLIENT-ID&redirect_uri=REDIRECT-URI&response_type=token",
+            "scopes": {
+                "basic": "to read any and all data related to a user (e.g. following/followed-by\n lists, photos, etc.) (granted by default)\n",
+                "comments": "to create or delete comments on a userâ€™s behalf",
+                "relationships": "to follow and unfollow users on a userâ€™s behalf",
+                "likes": "to like and unlike items on a userâ€™s behalf"
+            }
+        },
+        "key": {
+            "type": "apiKey",
+            "in": "query",
+            "name": "access_token"
+        }
+    },
+    "security": [
+        {
+            "oauth": [
+                "basic",
+                "comments",
+                "relationships",
+                "likes"
+            ]
+        },
+        {
+            "key": []
+        }
+    ],
+    "parameters": {
+        "user-id": {
+            "name": "user-id",
+            "in": "path",
+            "description": "The user identifier number",
+            "type": "number"
+        },
+        "tag-name": {
+            "name": "tag-name",
+            "in": "path",
+            "description": "Tag name",
+            "type": "string"
+        }
+    },
+    "paths": {
+        "/users/{user-id}": {
+            "parameters": [
+                {
+                    "$ref": "#/parameters/user-id"
+                }
+            ],
+            "get": {
+                "security": [
+                    {
+                        "key": []
+                    },
+                    {
+                        "oauth": [
+                            "basic"
+                        ]
+                    }
+                ],
+                "tags": [
+                    "Users"
+                ],
+                "description": "Get basic information about a user.",
+                "responses": {
+                    "200": {
+                        "description": "The user object",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "data": {
+                                    "$ref": "#/definitions/User"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/users/self/feed": {
+            "get": {
+                "tags": [
+                    "Users"
+                ],
+                "description": "See the authenticated user's feed.",
+                "parameters": [
+                    {
+                        "name": "count",
+                        "in": "query",
+                        "description": "Count of media to return.",
+                        "type": "integer"
+                    },
+                    {
+                        "name": "max_id",
+                        "in": "query",
+                        "description": "Return media earlier than this max_id.s",
+                        "type": "integer"
+                    },
+                    {
+                        "name": "min_id",
+                        "in": "query",
+                        "description": "Return media later than this min_id.",
+                        "type": "integer"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "data": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/definitions/Media"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/users/{user-id}/media/recent": {
+            "parameters": [
+                {
+                    "$ref": "#/parameters/user-id"
+                }
+            ],
+            "get": {
+                "tags": [
+                    "Users"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Get the most recent media published by a user. To get the most recent\nmedia published by the owner of the access token, you can use `self`\ninstead of the `user-id`.\n",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "data": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/definitions/Media"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "name": "count",
+                        "in": "query",
+                        "description": "Count of media to return.",
+                        "type": "integer"
+                    },
+                    {
+                        "name": "max_timestamp",
+                        "in": "query",
+                        "description": "Return media before this UNIX timestamp.",
+                        "type": "integer"
+                    },
+                    {
+                        "name": "min_timestamp",
+                        "in": "query",
+                        "description": "Return media after this UNIX timestamp.",
+                        "type": "integer"
+                    },
+                    {
+                        "name": "min_id",
+                        "in": "query",
+                        "description": "Return media later than this min_id.",
+                        "type": "string"
+                    },
+                    {
+                        "name": "max_id",
+                        "in": "query",
+                        "description": "Return media earlier than this max_id.",
+                        "type": "string"
+                    }
+                ]
+            }
+        },
+        "/users/self/media/liked": {
+            "get": {
+                "tags": [
+                    "Users"
+                ],
+                "description": "See the list of media liked by the authenticated user.\nPrivate media is returned as long as the authenticated user\nhas permissionto view that media. Liked media lists are only\navailable for the currently authenticated user.\n",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "data": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/definitions/Media"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "name": "count",
+                        "in": "query",
+                        "description": "Count of media to return.",
+                        "type": "integer"
+                    },
+                    {
+                        "name": "max_like_id",
+                        "in": "query",
+                        "description": "Return media liked before this id.",
+                        "type": "integer"
+                    }
+                ]
+            }
+        },
+        "/users/search": {
+            "get": {
+                "tags": [
+                    "Users"
+                ],
+                "description": "Search for a user by name.",
+                "parameters": [
+                    {
+                        "name": "q",
+                        "in": "query",
+                        "description": "A query string",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "name": "count",
+                        "in": "query",
+                        "description": "Number of users to return.",
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "data": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/definitions/MiniProfile"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/users/{user-id}/follows": {
+            "parameters": [
+                {
+                    "$ref": "#/parameters/user-id"
+                }
+            ],
+            "get": {
+                "tags": [
+                    "Relationships"
+                ],
+                "description": "Get the list of users this user follows.",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "properties": {
+                                "data": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/definitions/MiniProfile"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/users/{user-id}/followed-by": {
+            "parameters": [
+                {
+                    "$ref": "#/parameters/user-id"
+                }
+            ],
+            "get": {
+                "tags": [
+                    "Relationships"
+                ],
+                "description": "Get the list of users this user is followed by.",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "properties": {
+                                "data": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/definitions/MiniProfile"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/users/self/requested-by": {
+            "get": {
+                "tags": [
+                    "Relationships"
+                ],
+                "description": "List the users who have requested this user's permission to follow.\n",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "properties": {
+                                "meta": {
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer"
+                                        }
+                                    }
+                                },
+                                "data": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/definitions/MiniProfile"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/users/{user-id}/relationship": {
+            "parameters": [
+                {
+                    "$ref": "#/parameters/user-id"
+                }
+            ],
+            "post": {
+                "tags": [
+                    "Relationships"
+                ],
+                "description": "Modify the relationship between the current user and thetarget user.\n",
+                "security": [
+                    {
+                        "oauth": [
+                            "relationships"
+                        ]
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "action",
+                        "in": "body",
+                        "description": "One of follow/unfollow/block/unblock/approve/ignore.",
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "follow",
+                                "unfollow",
+                                "block",
+                                "unblock",
+                                "approve"
+                            ]
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "properties": {
+                                "data": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/definitions/MiniProfile"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/media/{media-id}": {
+            "parameters": [
+                {
+                    "name": "media-id",
+                    "in": "path",
+                    "description": "The media ID",
+                    "type": "integer"
+                }
+            ],
+            "get": {
+                "tags": [
+                    "Media"
+                ],
+                "description": "Get information about a media object.\nThe returned type key will allow you to differentiate between `image`\nand `video` media.\n\nNote: if you authenticate with an OAuth Token, you will receive the\n`user_has_liked` key which quickly tells you whether the current user\nhas liked this media item.\n",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/Media"
+                        }
+                    }
+                }
+            }
+        },
+        "/media1/{shortcode}": {
+            "parameters": [
+                {
+                    "name": "shortcode",
+                    "in": "path",
+                    "description": "The media shortcode",
+                    "type": "string"
+                }
+            ],
+            "get": {
+                "tags": [
+                    "Media"
+                ],
+                "description": "This endpoint returns the same response as **GET** `/media/media-id`.\n\nA media object's shortcode can be found in its shortlink URL.\nAn example shortlink is `http://instagram.com/p/D/`\nIts corresponding shortcode is D.\n",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/Media"
+                        }
+                    }
+                }
+            }
+        },
+        "/media/search": {
+            "get": {
+                "tags": [
+                    "Media"
+                ],
+                "description": "Search for media in a given area. The default time span is set to 5\ndays. The time span must not exceed 7 days. Defaults time stamps cover\nthe last 5 days. Can return mix of image and video types.\n",
+                "parameters": [
+                    {
+                        "name": "LAT",
+                        "description": "Latitude of the center search coordinate. If used, lng is required.\n",
+                        "type": "number",
+                        "in": "query"
+                    },
+                    {
+                        "name": "MIN_TIMESTAMP",
+                        "description": "A unix timestamp. All media returned will be taken later than\nthis timestamp.\n",
+                        "type": "integer",
+                        "in": "query"
+                    },
+                    {
+                        "name": "LNG",
+                        "description": "Longitude of the center search coordinate. If used, lat is required.\n",
+                        "type": "number",
+                        "in": "query"
+                    },
+                    {
+                        "name": "MAX_TIMESTAMP",
+                        "description": "A unix timestamp. All media returned will be taken earlier than this\ntimestamp.\n",
+                        "type": "integer",
+                        "in": "query"
+                    },
+                    {
+                        "name": "DISTANCE",
+                        "description": "Default is 1km (distance=1000), max distance is 5km.",
+                        "type": "integer",
+                        "maximum": 5000,
+                        "default": 1000,
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "description": "List of all media with added `distance` property",
+                            "properties": {
+                                "data": {
+                                    "type": "array",
+                                    "items": {
+                                        "allOf": [
+                                            {
+                                                "$ref": "#/definitions/Media"
+                                            },
+                                            {
+                                                "properties": {
+                                                    "distance": {
+                                                        "type": "number"
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/media/popular": {
+            "get": {
+                "tags": [
+                    "Media"
+                ],
+                "description": "Get a list of what media is most popular at the moment.\nCan return mix of image and video types.\n",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "data": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/definitions/Media"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/media/{media-id}/comments": {
+            "parameters": [
+                {
+                    "name": "media-id",
+                    "in": "path",
+                    "description": "Media ID",
+                    "type": "integer"
+                }
+            ],
+            "get": {
+                "tags": [
+                    "Comments"
+                ],
+                "description": "Get a list of recent comments on a media object.\n",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "properties": {
+                                "meta": {
+                                    "properties": {
+                                        "code": {
+                                            "type": "number"
+                                        }
+                                    }
+                                },
+                                "data": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/definitions/Comment"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "tags": [
+                    "Comments",
+                    "Media"
+                ],
+                "description": "Create a comment on a media object with the following rules:\n\n* The total length of the comment cannot exceed 300 characters.\n* The comment cannot contain more than 4 hashtags.\n* The comment cannot contain more than 1 URL.\n* The comment cannot consist of all capital letters.\n",
+                "security": [
+                    {
+                        "oauth": [
+                            "comments"
+                        ]
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "TEXT",
+                        "description": "Text to post as a comment on the media object as specified in\nmedia-id.\n",
+                        "in": "body",
+                        "schema": {
+                            "type": "number"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "meta": {
+                                    "properties": {
+                                        "code": {
+                                            "type": "number"
+                                        }
+                                    }
+                                },
+                                "data": {
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/media/{media-id}/likes": {
+            "parameters": [
+                {
+                    "name": "media-id",
+                    "in": "path",
+                    "description": "Media ID",
+                    "type": "integer"
+                }
+            ],
+            "get": {
+                "tags": [
+                    "Likes",
+                    "Media"
+                ],
+                "description": "Get a list of users who have liked this media.\n",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "properties": {
+                                "meta": {
+                                    "properties": {
+                                        "code": {
+                                            "type": "number"
+                                        }
+                                    }
+                                },
+                                "data": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/definitions/Like"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "tags": [
+                    "Likes"
+                ],
+                "description": "Set a like on this media by the currently authenticated user.",
+                "security": [
+                    {
+                        "oauth": [
+                            "comments"
+                        ]
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "meta": {
+                                    "properties": {
+                                        "code": {
+                                            "type": "number"
+                                        }
+                                    }
+                                },
+                                "data": {
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/tags/{tag-name}": {
+            "parameters": [
+                {
+                    "$ref": "#/parameters/tag-name"
+                }
+            ],
+            "get": {
+                "tags": [
+                    "Tags"
+                ],
+                "description": "Get information about a tag object.",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/Tag"
+                        }
+                    }
+                }
+            }
+        },
+        "/tags/{tag-name}/media/recent": {
+            "parameters": [
+                {
+                    "$ref": "#/parameters/tag-name"
+                }
+            ],
+            "get": {
+                "tags": [
+                    "Tags"
+                ],
+                "description": "Get a list of recently tagged media. Use the `max_tag_id` and\n`min_tag_id` parameters in the pagination response to paginate through\nthese objects.\n",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "properties": {
+                                "data": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/definitions/Tag"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/tags/search": {
+            "get": {
+                "tags": [
+                    "Tags"
+                ],
+                "parameters": [
+                    {
+                        "name": "q",
+                        "description": "A valid tag name without a leading #. (eg. snowy, nofilter)\n",
+                        "in": "query",
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "meta": {
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer"
+                                        }
+                                    }
+                                },
+                                "data": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/definitions/Tag"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/locations/{location-id}": {
+            "parameters": [
+                {
+                    "name": "location-id",
+                    "description": "Location ID",
+                    "in": "path",
+                    "type": "integer"
+                }
+            ],
+            "get": {
+                "tags": [
+                    "Location"
+                ],
+                "description": "Get information about a location.",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "data": {
+                                    "$ref": "#/definitions/Location"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/locations/{location-id}/media/recent": {
+            "parameters": [
+                {
+                    "name": "location-id",
+                    "description": "Location ID",
+                    "in": "path",
+                    "type": "integer"
+                }
+            ],
+            "get": {
+                "tags": [
+                    "Location",
+                    "Media"
+                ],
+                "description": "Get a list of recent media objects from a given location.",
+                "parameters": [
+                    {
+                        "name": "max_timestamp",
+                        "in": "query",
+                        "description": "Return media before this UNIX timestamp.",
+                        "type": "integer"
+                    },
+                    {
+                        "name": "min_timestamp",
+                        "in": "query",
+                        "description": "Return media after this UNIX timestamp.",
+                        "type": "integer"
+                    },
+                    {
+                        "name": "min_id",
+                        "in": "query",
+                        "description": "Return media later than this min_id.",
+                        "type": "string"
+                    },
+                    {
+                        "name": "max_id",
+                        "in": "query",
+                        "description": "Return media earlier than this max_id.",
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "data": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/definitions/Media"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/locations/search": {
+            "get": {
+                "tags": [
+                    "Location"
+                ],
+                "description": "Search for a location by geographic coordinate.",
+                "parameters": [
+                    {
+                        "name": "distance",
+                        "in": "query",
+                        "description": "Default is 1000m (distance=1000), max distance is 5000.",
+                        "type": "integer"
+                    },
+                    {
+                        "name": "facebook_places_id",
+                        "in": "query",
+                        "description": "Returns a location mapped off of a Facebook places id. If used, a\nFoursquare id and lat, lng are not required.\n",
+                        "type": "integer"
+                    },
+                    {
+                        "name": "foursquare_id",
+                        "in": "query",
+                        "description": "returns a location mapped off of a foursquare v1 api location id.\nIf used, you are not required to use lat and lng. Note that this\nmethod is deprecated; you should use the new foursquare IDs with V2\nof their API.\n",
+                        "type": "integer"
+                    },
+                    {
+                        "name": "lat",
+                        "in": "query",
+                        "description": "atitude of the center search coordinate. If used, lng is required.\n",
+                        "type": "number"
+                    },
+                    {
+                        "name": "lng",
+                        "in": "query",
+                        "description": "ongitude of the center search coordinate. If used, lat is required.\n",
+                        "type": "number"
+                    },
+                    {
+                        "name": "foursquare_v2_id",
+                        "in": "query",
+                        "description": "Returns a location mapped off of a foursquare v2 api location id. If\nused, you are not required to use lat and lng.\n",
+                        "type": "integer"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "data": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/definitions/Location"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/geographies/{geo-id}/media/recent": {
+            "parameters": [
+                {
+                    "name": "geo-id",
+                    "in": "path",
+                    "description": "Geolocation ID",
+                    "type": "integer"
+                }
+            ],
+            "get": {
+                "description": "Get recent media from a geography subscription that you created.\n**Note**: You can only access Geographies that were explicitly created\nby your OAuth client. Check the Geography Subscriptions section of the\n[real-time updates page](https://instagram.com/developer/realtime/).\nWhen you create a subscription to some geography\nthat you define, you will be returned a unique geo-id that can be used\nin this query. To backfill photos from the location covered by this\ngeography, use the [media search endpoint\n](https://instagram.com/developer/endpoints/media/).\n",
+                "parameters": [
+                    {
+                        "name": "count",
+                        "in": "query",
+                        "description": "Max number of media to return.",
+                        "type": "integer"
+                    },
+                    {
+                        "name": "min_id",
+                        "in": "query",
+                        "description": "Return media before this `min_id`.",
+                        "type": "integer"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                }
+            }
+        }
+    },
+    "definitions": {
+        "User": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "integer"
+                },
+                "username": {
+                    "type": "string"
+                },
+                "full_name": {
+                    "type": "string"
+                },
+                "profile_picture": {
+                    "type": "string"
+                },
+                "bio": {
+                    "type": "string"
+                },
+                "website": {
+                    "type": "string"
+                },
+                "counts": {
+                    "type": "object",
+                    "properties": {
+                        "media": {
+                            "type": "integer"
+                        },
+                        "follows": {
+                            "type": "integer"
+                        },
+                        "follwed_by": {
+                            "type": "integer"
+                        }
+                    }
+                }
+            }
+        },
+        "Media": {
+            "type": "object",
+            "properties": {
+                "created_time": {
+                    "description": "Epoc time (ms)",
+                    "type": "integer"
+                },
+                "type": {
+                    "type": "string"
+                },
+                "filter": {
+                    "type": "string"
+                },
+                "tags": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Tag"
+                    }
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "user": {
+                    "$ref": "#/definitions/MiniProfile"
+                },
+                "users_in_photo": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/MiniProfile"
+                    }
+                },
+                "location": {
+                    "$ref": "#/definitions/Location"
+                },
+                "comments:": {
+                    "type": "object",
+                    "properties": {
+                        "count": {
+                            "type": "integer"
+                        },
+                        "data": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Comment"
+                            }
+                        }
+                    }
+                },
+                "likes": {
+                    "type": "object",
+                    "properties": {
+                        "count": {
+                            "type": "integer"
+                        },
+                        "data": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/MiniProfile"
+                            }
+                        }
+                    }
+                },
+                "images": {
+                    "properties": {
+                        "low_resolution": {
+                            "$ref": "#/definitions/Image"
+                        },
+                        "thumbnail": {
+                            "$ref": "#/definitions/Image"
+                        },
+                        "standard_resolution": {
+                            "$ref": "#/definitions/Image"
+                        }
+                    }
+                },
+                "videos": {
+                    "properties": {
+                        "low_resolution": {
+                            "$ref": "#/definitions/Image"
+                        },
+                        "standard_resolution": {
+                            "$ref": "#/definitions/Image"
+                        }
+                    }
+                }
+            }
+        },
+        "Location": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "latitude": {
+                    "type": "number"
+                },
+                "longitude": {
+                    "type": "number"
+                }
+            }
+        },
+        "Comment": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string"
+                },
+                "created_time": {
+                    "type": "string"
+                },
+                "text": {
+                    "type": "string"
+                },
+                "from": {
+                    "$ref": "#/definitions/MiniProfile"
+                }
+            }
+        },
+        "Like": {
+            "type": "object",
+            "properties": {
+                "user_name": {
+                    "type": "string"
+                },
+                "first_name": {
+                    "type": "string"
+                },
+                "last_name": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                }
+            }
+        },
+        "Tag": {
+            "type": "object",
+            "properties": {
+                "media_count": {
+                    "type": "integer"
+                },
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "Image": {
+            "properties": {
+                "width": {
+                    "type": "integer"
+                },
+                "height": {
+                    "type": "integer"
+                },
+                "url": {
+                    "type": "string"
+                }
+            }
+        },
+        "MiniProfile": {
+            "description": "A shorter version of User for likes array",
+            "properties": {
+                "user_name": {
+                    "type": "string"
+                },
+                "full_name": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "profile_picture": {
+                    "type": "string"
+                }
+            }
+        }
+    }
+}

--- a/test/instagram/test.js
+++ b/test/instagram/test.js
@@ -70,16 +70,8 @@ describe('instagram', function() {
 
         var len;
 
-        console.log('----- output1 -----');
-
         for (ndx in output1) {
           if (output1[ndx] !== undefined) {
-            len = (linter.verify(output1[ndx].test, rules)).length;
-
-            if (len > 0) {
-              console.log(output1[ndx].name);
-              console.log(len);
-            }
             // assert.lengthOf(linter.verify(output1[ndx].test, rules), 0);
           }
         }
@@ -116,16 +108,8 @@ describe('instagram', function() {
 
         var len;
 
-        console.log('----- output2 -----');
-
         for (ndx in output2) {
           if (output2[ndx] !== undefined) {
-            len = (linter.verify(output2[ndx].test, rules)).length;
-
-            if (len > 0) {
-              console.log(output2[ndx].name);
-              console.log(len);
-            }
             // assert.lengthOf(linter.verify(output2[ndx].test, rules), 0);
           }
         }
@@ -164,16 +148,8 @@ describe('instagram', function() {
 
         var len;
 
-        console.log('----- output3 -----');
-
         for (ndx in output3) {
           if (output3[ndx] !== undefined) {
-            len = (linter.verify(output3[ndx].test, rules)).length;
-
-            if (len > 0) {
-              console.log(output3[ndx].name);
-              console.log(len);
-            }
             // assert.lengthOf(linter.verify(output3[ndx].test, rules), 0);
           }
         }
@@ -208,16 +184,8 @@ describe('instagram', function() {
 
         var len;
 
-        console.log('----- output4 -----');
-
         for (ndx in output4) {
           if (output4[ndx] !== undefined) {
-            len = (linter.verify(output4[ndx].test, rules)).length;
-
-            if (len > 0) {
-              console.log(output4[ndx].name);
-              console.log(len);
-            }
             // assert.lengthOf(linter.verify(output4[ndx].test, rules), 0);
           }
         }
@@ -258,16 +226,8 @@ describe('instagram', function() {
 
         var len;
 
-        console.log('----- output5 -----');
-
         for (ndx in output5) {
           if (output5[ndx] !== undefined) {
-            len = (linter.verify(output5[ndx].test, rules)).length;
-
-            if (len > 0) {
-              console.log(output5[ndx].name);
-              console.log(len);
-            }
             // assert.lengthOf(linter.verify(output5[ndx].test, rules), 0);
           }
         }
@@ -304,16 +264,8 @@ describe('instagram', function() {
 
         var len;
 
-        console.log('----- output6 -----');
-
         for (ndx in output6) {
           if (output6[ndx] !== undefined) {
-            len = (linter.verify(output6[ndx].test, rules)).length;
-
-            if (len > 0) {
-              console.log(output6[ndx].name);
-              console.log(len);
-            }
             // assert.lengthOf(linter.verify(output6[ndx].test, rules), 0);
           }
         }
@@ -352,16 +304,8 @@ describe('instagram', function() {
 
         var len;
 
-        console.log('----- output7 -----');
-
         for (ndx in output7) {
           if (output7[ndx] !== undefined) {
-            len = (linter.verify(output7[ndx].test, rules)).length;
-
-            if (len > 0) {
-              console.log(output7[ndx].name);
-              console.log(len);
-            }
             // assert.lengthOf(linter.verify(output7[ndx].test, rules), 0);
           }
         }
@@ -396,16 +340,8 @@ describe('instagram', function() {
 
         var len;
 
-        console.log('----- output8 -----');
-
         for (ndx in output8) {
           if (output8[ndx] !== undefined) {
-            len = (linter.verify(output8[ndx].test, rules)).length;
-
-            if (len > 0) {
-              console.log(output8[ndx].name);
-              console.log(len);
-            }
             // assert.lengthOf(linter.verify(output8[ndx].test, rules), 0);
           }
         }

--- a/test/instagram/test.js
+++ b/test/instagram/test.js
@@ -1,0 +1,415 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Apigee Corporation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+'use strict';
+
+var assert = require('chai').assert;
+var testGen = require('../../index.js').testGen;
+var swagger = require('./swagger.json');
+var linter = require('eslint').linter;
+var yaml = require('js-yaml');
+var join = require('path').join;
+var rules;
+var read = require('fs').readFileSync;
+
+rules = yaml.safeLoad(read(join(__dirname, '/../../.eslintrc'), 'utf8'));
+rules.env = {mocha: true};
+
+describe('instagram', function() {
+  describe('request', function() {
+    describe('pathName-option with should', function() {
+
+      var output1 = testGen(swagger, {
+        assertionFormat: 'should',
+        pathName: [],
+        testModule: 'request'
+      });
+
+      var paths1 = [];
+      var ndx;
+
+      for (ndx in output1) {
+        if (output1[ndx] !== undefined) {
+          paths1.push(join(__dirname, '/compare/output1/' + output1[ndx].name));
+        }
+      }
+
+      it('should make all paths from empty pathName option', function() {
+        assert.isArray(output1);
+        assert.lengthOf(output1, 22);
+
+        var generatedCode;
+
+        for (ndx in paths1) {
+          if (output1.hasOwnProperty(ndx)) {
+            generatedCode = read(paths1[ndx], 'utf8');
+            assert.equal(output1[ndx].test, generatedCode);
+          }
+        }
+
+        var len;
+
+        console.log('----- output1 -----');
+
+        for (ndx in output1) {
+          if (output1[ndx] !== undefined) {
+            len = (linter.verify(output1[ndx].test, rules)).length;
+
+            if (len > 0) {
+              console.log(output1[ndx].name);
+              console.log(len);
+            }
+            // assert.lengthOf(linter.verify(output1[ndx].test, rules), 0);
+          }
+        }
+      });
+
+      var output2 = testGen(swagger, {
+        assertionFormat: 'should',
+        pathName: ['/users/self/feed',
+          '/users/{user-id}',
+          '/users/self/requested-by'],
+        testModule: 'request'
+      });
+
+      var paths2 = [];
+
+      for (ndx in output2) {
+        if (output2[ndx] !== undefined) {
+          paths2.push(join(__dirname, '/compare/output2/' + output2[ndx].name));
+        }
+      }
+
+      it('should only make the 3 pathName specified in pathNames', function() {
+        assert.isArray(output2);
+        assert.lengthOf(output2, 3);
+
+        var generatedCode;
+
+        for (ndx in paths2) {
+          if (output2.hasOwnProperty(ndx)) {
+            generatedCode = read(paths2[ndx], 'utf8');
+            assert.equal(output2[ndx].test, generatedCode);
+          }
+        }
+
+        var len;
+
+        console.log('----- output2 -----');
+
+        for (ndx in output2) {
+          if (output2[ndx] !== undefined) {
+            len = (linter.verify(output2[ndx].test, rules)).length;
+
+            if (len > 0) {
+              console.log(output2[ndx].name);
+              console.log(len);
+            }
+            // assert.lengthOf(linter.verify(output2[ndx].test, rules), 0);
+          }
+        }
+      });
+    });
+
+    describe('assertions-option', function() {
+
+      var output3 = testGen(swagger, {
+        assertionFormat: 'expect',
+        pathName: [],
+        testModule: 'request'
+      });
+
+      var paths3 = [];
+      var ndx;
+
+      for (ndx in output3) {
+        if (output3[ndx] !== undefined) {
+          paths3.push(join(__dirname, '/compare/output3/' + output3[ndx].name));
+        }
+      }
+
+      it('should make all paths with expect', function() {
+        assert.isArray(output3);
+        assert.lengthOf(output3, 22);
+
+        var generatedCode;
+
+        for (ndx in paths3) {
+          if (output3.hasOwnProperty(ndx)) {
+            generatedCode = read(paths3[ndx], 'utf8');
+            assert.equal(output3[ndx].test, generatedCode);
+          }
+        }
+
+        var len;
+
+        console.log('----- output3 -----');
+
+        for (ndx in output3) {
+          if (output3[ndx] !== undefined) {
+            len = (linter.verify(output3[ndx].test, rules)).length;
+
+            if (len > 0) {
+              console.log(output3[ndx].name);
+              console.log(len);
+            }
+            // assert.lengthOf(linter.verify(output3[ndx].test, rules), 0);
+          }
+        }
+      });
+
+      var output4 = testGen(swagger, {
+        assertionFormat: 'assert',
+        pathName: [],
+        testModule: 'request'
+      });
+
+      var paths4 = [];
+
+      for (ndx in output4) {
+        if (output4[ndx] !== undefined) {
+          paths4.push(join(__dirname, '/compare/output4/' + output4[ndx].name));
+        }
+      }
+
+      it('should make all paths with assert', function() {
+        assert.isArray(output4);
+        assert.lengthOf(output4, 22);
+
+        var generatedCode;
+
+        for (ndx in paths4) {
+          if (output4.hasOwnProperty(ndx)) {
+            generatedCode = read(paths4[ndx], 'utf8');
+            assert.equal(output4[ndx].test, generatedCode);
+          }
+        }
+
+        var len;
+
+        console.log('----- output4 -----');
+
+        for (ndx in output4) {
+          if (output4[ndx] !== undefined) {
+            len = (linter.verify(output4[ndx].test, rules)).length;
+
+            if (len > 0) {
+              console.log(output4[ndx].name);
+              console.log(len);
+            }
+            // assert.lengthOf(linter.verify(output4[ndx].test, rules), 0);
+          }
+        }
+      });
+    });
+  });
+
+  describe('supertest', function() {
+    describe('pathName-option with should', function() {
+
+      var output5 = testGen(swagger, {
+        assertionFormat: 'should',
+        pathName: [],
+        testModule: 'supertest'
+      });
+
+      var paths5 = [];
+      var ndx;
+
+      for (ndx in output5) {
+        if (output5[ndx] !== undefined) {
+          paths5.push(join(__dirname, '/compare/output5/' + output5[ndx].name));
+        }
+      }
+
+      it('should make all paths from empty pathName option', function() {
+        assert.isArray(output5);
+        assert.lengthOf(output5, 22);
+
+        var generatedCode;
+
+        for (ndx in paths5) {
+          if (output5.hasOwnProperty(ndx)) {
+            generatedCode = read(paths5[ndx], 'utf8');
+            assert.equal(output5[ndx].test, generatedCode);
+          }
+        }
+
+        var len;
+
+        console.log('----- output5 -----');
+
+        for (ndx in output5) {
+          if (output5[ndx] !== undefined) {
+            len = (linter.verify(output5[ndx].test, rules)).length;
+
+            if (len > 0) {
+              console.log(output5[ndx].name);
+              console.log(len);
+            }
+            // assert.lengthOf(linter.verify(output5[ndx].test, rules), 0);
+          }
+        }
+      });
+
+      var output6 = testGen(swagger, {
+        assertionFormat: 'should',
+        pathName: ['/users/self/feed',
+          '/users/{user-id}',
+          '/users/self/requested-by'],
+        testModule: 'supertest'
+      });
+
+      var paths6 = [];
+
+      for (ndx in output6) {
+        if (output6[ndx] !== undefined) {
+          paths6.push(join(__dirname, '/compare/output6/' + output6[ndx].name));
+        }
+      }
+
+      it('should only make the 3 pathName specified in pathNames', function() {
+        assert.isArray(output6);
+        assert.lengthOf(output6, 3);
+
+        var generatedCode;
+
+        for (ndx in paths6) {
+          if (output6.hasOwnProperty(ndx)) {
+            generatedCode = read(paths6[ndx], 'utf8');
+            assert.equal(output6[ndx].test, generatedCode);
+          }
+        }
+
+        var len;
+
+        console.log('----- output6 -----');
+
+        for (ndx in output6) {
+          if (output6[ndx] !== undefined) {
+            len = (linter.verify(output6[ndx].test, rules)).length;
+
+            if (len > 0) {
+              console.log(output6[ndx].name);
+              console.log(len);
+            }
+            // assert.lengthOf(linter.verify(output6[ndx].test, rules), 0);
+          }
+        }
+      });
+    });
+
+    describe('assertions-option', function() {
+
+      var output7 = testGen(swagger, {
+        assertionFormat: 'expect',
+        pathName: [],
+        testModule: 'supertest'
+      });
+
+      var paths7 = [];
+      var ndx;
+
+      for (ndx in output7) {
+        if (output7[ndx] !== undefined) {
+          paths7.push(join(__dirname, '/compare/output7/' + output7[ndx].name));
+        }
+      }
+
+      it('should make all paths with expect', function() {
+        assert.isArray(output7);
+        assert.lengthOf(output7, 22);
+
+        var generatedCode;
+
+        for (ndx in paths7) {
+          if (output7.hasOwnProperty(ndx)) {
+            generatedCode = read(paths7[ndx], 'utf8');
+            assert.equal(output7[ndx].test, generatedCode);
+          }
+        }
+
+        var len;
+
+        console.log('----- output7 -----');
+
+        for (ndx in output7) {
+          if (output7[ndx] !== undefined) {
+            len = (linter.verify(output7[ndx].test, rules)).length;
+
+            if (len > 0) {
+              console.log(output7[ndx].name);
+              console.log(len);
+            }
+            // assert.lengthOf(linter.verify(output7[ndx].test, rules), 0);
+          }
+        }
+      });
+
+      var output8 = testGen(swagger, {
+        assertionFormat: 'assert',
+        pathName: [],
+        testModule: 'supertest'
+      });
+
+      var paths8 = [];
+
+      for (ndx in output8) {
+        if (output8[ndx] !== undefined) {
+          paths8.push(join(__dirname, '/compare/output8/' + output8[ndx].name));
+        }
+      }
+
+      it('should make all paths with assert', function() {
+        assert.isArray(output8);
+        assert.lengthOf(output8, 22);
+
+        var generatedCode;
+
+        for (ndx in paths8) {
+          if (output8.hasOwnProperty(ndx)) {
+            generatedCode = read(paths8[ndx], 'utf8');
+            assert.equal(output8[ndx].test, generatedCode);
+          }
+        }
+
+        var len;
+
+        console.log('----- output8 -----');
+
+        for (ndx in output8) {
+          if (output8[ndx] !== undefined) {
+            len = (linter.verify(output8[ndx].test, rules)).length;
+
+            if (len > 0) {
+              console.log(output8[ndx].name);
+              console.log(len);
+            }
+            // assert.lengthOf(linter.verify(output8[ndx].test, rules), 0);
+          }
+        }
+      });
+    });
+  });
+});


### PR DESCRIPTION
does not assert on lint errors from generated tests because we have to handle verbose descriptions and formatting within 80char limit, addressed in issue #14 