### PR TITLE
Handle multiple consume/produce types

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,6 +24,8 @@
 
 'use strict';
 
+var TYPE_JSON = 'application/json';
+
 var handlebars = require('handlebars');
 var read = require('fs').readFileSync;
 var join = require('path').join;
@@ -188,7 +190,7 @@ function testGenResponse(swagger, path, operation, response, config,
 
   // get the data
   data = getData(swagger, path, operation, response, config);
-  if (produce === 'application/json' && !data.noSchema) {
+  if (produce === TYPE_JSON && !data.noSchema) {
     importValidator = true;
   }
 
@@ -227,7 +229,7 @@ function testGenContentTypes(swagger, path, operation, res, config) {
       } else { // produces is not defined
         result.push(testGenResponse(
           swagger, path, operation, res, config,
-          consumes[ndxC], 'application/json'));
+          consumes[ndxC], TYPE_JSON));
       }
     }
   } else if (!isEmpty(produces)) {
@@ -236,13 +238,13 @@ function testGenContentTypes(swagger, path, operation, res, config) {
       if (produces[ndxP] !== undefined) {
         result.push(testGenResponse(
           swagger, path, operation, res, config,
-          'application/json', produces[ndxP]));
+          TYPE_JSON, produces[ndxP]));
       }
     }
   } else { // neither produces nor consumes are defined
     result.push(testGenResponse(
       swagger, path, operation, res, config,
-      'application/json', 'application/json'));
+      TYPE_JSON, TYPE_JSON));
   }
 
   return result;
@@ -423,7 +425,7 @@ handlebars.registerHelper('validateResponse', function(type, noSchema,
       'needs 2 parameters');
   }
 
-  if (!noSchema && type === 'application/json') {
+  if (!noSchema && type === TYPE_JSON) {
     return options.fn(this);
   } else {
     return options.inverse(this);

--- a/index.js
+++ b/index.js
@@ -414,7 +414,7 @@ handlebars.registerHelper('is', function(lvalue, rvalue, options) {
  * @param  {string} type     content type to be evaluated
  * @param  {boolean} noSchema whether or not there is a defined schema
  * @param  {Object} options  handlebars built-in options
- * @return {boolean}          whether or not the content can be validated
+ * @returns {boolean}          whether or not the content can be validated
  */
 handlebars.registerHelper('validateResponse', function(type, noSchema,
   options) {

--- a/index.js
+++ b/index.js
@@ -409,6 +409,13 @@ handlebars.registerHelper('is', function(lvalue, rvalue, options) {
   }
 });
 
+/**
+ * determines if content types are able to be validated
+ * @param  {string} type     content type to be evaluated
+ * @param  {boolean} noSchema whether or not there is a defined schema
+ * @param  {Object} options  handlebars built-in options
+ * @return {boolean}          whether or not the content can be validated
+ */
 handlebars.registerHelper('validateResponse', function(type, noSchema,
   options) {
   if (arguments.length < 3) {

--- a/templates/outerDescribe.handlebars
+++ b/templates/outerDescribe.handlebars
@@ -1,9 +1,9 @@
 'use strict';
 var chai = require('chai');
-{{#unless noResponseDefinitions}}
+{{#if importValidator}}
 var ZSchema = require('z-schema');
 var validator = new ZSchema({});
-{{/unless}}
+{{/if}}
 {{#is assertion 'expect'}}
 var expect = chai.expect;
 {{/is}}

--- a/templates/request/get/get.handlebars
+++ b/templates/request/get/get.handlebars
@@ -1,16 +1,16 @@
   it('should respond with {{description}}', function(done) {
-      {{#unless noSchema}}
+      {{#validateResponse returnType noSchema}}
       /*eslint-disable*/
       {{> schema-partial this}}
 
       /*eslint-enable*/
-      {{/unless}}
+      {{/validateResponse}}
       request({
         url: '{{path}}',
         {{#if queryParameters}}
         qs: {
         {{#each queryParameters}}
-        {{this.name}}: 'DATA GOES HERE'{{#unless @last}},{{/unless}}
+          {{this.name}}: 'DATA GOES HERE'{{#unless @last}},{{/unless}}
         {{/each}}
         },
         {{/if}}
@@ -27,18 +27,17 @@
         if (error) {
           return done(error);
         }
-        {{#if noSchema}}
-        {{#is ../assertion 'expect'}}
-        expect(body).to.equal(null);
+        {{#is assertion 'expect'}}
+        expect(res.statusCode).to.equal({{responseCode}});
         {{/is}}
-        {{#is ../assertion 'should'}}
-        body.should.equal(null);
+        {{#is assertion 'should'}}
+        res.statusCode.should.equal({{responseCode}});
         {{/is}}
-        {{#is ../assertion 'assert'}}
-        assert.isNull(body);
+        {{#is assertion 'assert'}}
+        assert.equal(res.statusCode, {{responseCode}});
         {{/is}}
-        {{/if}}
-        {{#unless noSchema}}
+
+        {{#validateResponse returnType noSchema}}
         {{#is ../assertion 'expect'}}
         expect(validator.validate(body, schema)).to.be.true;
         {{/is}}
@@ -48,7 +47,17 @@
         {{#is ../assertion 'assert'}}
         assert.true(validator.validate(body, schema));
         {{/is}}
-        {{/unless}}
+        {{else}}
+        {{#is ../assertion 'expect'}}
+        expect(body).to.equal(null); // non-json response or no schema
+        {{/is}}
+        {{#is ../assertion 'should'}}
+        body.should.equal(null); // non-json response or no schema
+        {{/is}}
+        {{#is ../assertion 'assert'}}
+        assert.isNull(body); // non-json response or no schema
+        {{/is}}
+        {{/validateResponse}}
         done();
       });
     });

--- a/templates/request/get/get.handlebars
+++ b/templates/request/get/get.handlebars
@@ -24,9 +24,8 @@
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         {{#is assertion 'expect'}}
         expect(res.statusCode).to.equal({{responseCode}});
         {{/is}}

--- a/templates/request/post/post.handlebars
+++ b/templates/request/post/post.handlebars
@@ -1,10 +1,10 @@
   it('should respond with {{description}}', function(done) {
-      {{#unless noSchema}}
+      {{#validateResponse returnType noSchema}}
       /*eslint-disable*/
       {{> schema-partial this}}
 
       /*eslint-enable*/
-      {{/unless}}
+      {{/validateResponse}}
       request({
         url: '{{path}}',
         {{#if queryParameters}}
@@ -46,22 +46,25 @@
         }
       },
         {{/is}}
+        {{#is contentType 'application/xml'}}
+        body: 'XML STRING GOES HERE'
+      },
+        {{/is}}
       function(error, res, body) {
         if (error) {
           return done(error);
         }
-        {{#if noSchema}}
-        {{#is ../assertion 'expect'}}
-        expect(body).to.equal(null);
+        {{#is assertion 'expect'}}
+        expect(res.statusCode).to.equal({{responseCode}});
         {{/is}}
-        {{#is ../assertion 'should'}}
-        body.should.equal(null);
+        {{#is assertion 'should'}}
+        res.statusCode.should.equal({{responseCode}});
         {{/is}}
-        {{#is ../assertion 'assert'}}
-        assert.isNull(body);
+        {{#is assertion 'assert'}}
+        assert.equal(res.statusCode, {{responseCode}});
         {{/is}}
-        {{/if}}
-        {{#unless noSchema}}
+
+        {{#validateResponse returnType noSchema}}
         {{#is ../assertion 'expect'}}
         expect(validator.validate(body, schema)).to.be.true;
         {{/is}}
@@ -71,7 +74,17 @@
         {{#is ../assertion 'assert'}}
         assert.true(validator.validate(body, schema));
         {{/is}}
-        {{/unless}}
+        {{else}}
+        {{#is ../assertion 'expect'}}
+        expect(body).to.equal(null); // non-json response or no schema
+        {{/is}}
+        {{#is ../assertion 'should'}}
+        body.should.equal(null); // non-json response or no schema
+        {{/is}}
+        {{#is ../assertion 'assert'}}
+        assert.isNull(body); // non-json response or no schema
+        {{/is}}
+        {{/validateResponse}}
         done();
       });
     });

--- a/templates/request/post/post.handlebars
+++ b/templates/request/post/post.handlebars
@@ -51,9 +51,8 @@
       },
         {{/is}}
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         {{#is assertion 'expect'}}
         expect(res.statusCode).to.equal({{responseCode}});
         {{/is}}

--- a/templates/request/put/put.handlebars
+++ b/templates/request/put/put.handlebars
@@ -1,10 +1,10 @@
   it('should respond with {{description}}', function(done) {
-      {{#unless noSchema}}
+      {{#validateResponse returnType noSchema}}
       /*eslint-disable*/
       {{> schema-partial this}}
 
       /*eslint-enable*/
-      {{/unless}}
+      {{/validateResponse}}
       request({
         url: '{{path}}',
         {{#if queryParameters}}
@@ -50,18 +50,17 @@
         if (error) {
           return done(error);
         }
-        {{#if noSchema}}
-        {{#is ../assertion 'expect'}}
-        expect(body).to.equal(null);
+        {{#is assertion 'expect'}}
+        expect(res.statusCode).to.equal({{responseCode}});
         {{/is}}
-        {{#is ../assertion 'should'}}
-        body.should.equal(null);
+        {{#is assertion 'should'}}
+        res.statusCode.should.equal({{responseCode}});
         {{/is}}
-        {{#is ../assertion 'assert'}}
-        assert.isNull(body);
+        {{#is assertion 'assert'}}
+        assert.equal(res.statusCode, {{responseCode}});
         {{/is}}
-        {{/if}}
-        {{#unless noSchema}}
+
+        {{#validateResponse returnType noSchema}}
         {{#is ../assertion 'expect'}}
         expect(validator.validate(body, schema)).to.be.true;
         {{/is}}
@@ -71,7 +70,17 @@
         {{#is ../assertion 'assert'}}
         assert.true(validator.validate(body, schema));
         {{/is}}
-        {{/unless}}
+        {{else}}
+        {{#is ../assertion 'expect'}}
+        expect(body).to.equal(null); // non-json response or no schema
+        {{/is}}
+        {{#is ../assertion 'should'}}
+        body.should.equal(null); // non-json response or no schema
+        {{/is}}
+        {{#is ../assertion 'assert'}}
+        assert.isNull(body); // non-json response or no schema
+        {{/is}}
+        {{/validateResponse}}
         done();
       });
     });

--- a/templates/request/put/put.handlebars
+++ b/templates/request/put/put.handlebars
@@ -47,9 +47,8 @@
       },
         {{/is}}
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         {{#is assertion 'expect'}}
         expect(res.statusCode).to.equal({{responseCode}});
         {{/is}}

--- a/templates/supertest/get/get.handlebars
+++ b/templates/supertest/get/get.handlebars
@@ -1,10 +1,10 @@
   it('should respond with {{description}}', function(done) {
-      {{#unless noSchema}}
+      {{#validateResponse returnType noSchema}}
       /*eslint-disable*/
       {{> schema-partial this}}
 
       /*eslint-enable*/
-      {{/unless}}
+      {{/validateResponse}}
       api.get('{{path}}')
       .set('Accept', '{{contentType}}')
       {{#if headerParameters}}
@@ -19,37 +19,28 @@
         if (err) {
           return done(err);
         }
-        {{#if noSchema}}
+
+        {{#validateResponse returnType noSchema}}
         {{#is ../assertion 'expect'}}
-        expect(res).to.equal(null);
+        expect(validator.validate(res.body, schema)).to.be.true;
         {{/is}}
         {{#is ../assertion 'should'}}
-        res.should.equal(null);
+        validator.validate(res.body, schema).should.be.true;
         {{/is}}
         {{#is ../assertion 'assert'}}
-        assert.isNull(res);
+        assert.true(validator.validate(res.body, schema));
         {{/is}}
-        {{/if}}
-        {{#unless noSchema}}
+        {{else}}
         {{#is ../assertion 'expect'}}
-        expect(validator.validate(res, schema)).to.be.true;
+        expect(res.body).to.equal(null); // non-json response or no schema
         {{/is}}
         {{#is ../assertion 'should'}}
-        validator.validate(res, schema).should.be.true;
+        res.body.should.equal(null); // non-json response or no schema
         {{/is}}
         {{#is ../assertion 'assert'}}
-        assert.true(validator.validate(res, schema));
+        assert.isNull(res.body); // non-json response or no schema
         {{/is}}
-        {{/unless}}
-        {{#is assertion 'expect'}}
-        expect(res).to.have.property('name');
-        {{/is}}
-        {{#is assertion 'should'}}
-        res.should.have.property('name');
-        {{/is}}
-        {{#is assertion 'assert'}}
-        assert.property(res, 'name');
-        {{/is}}
+        {{/validateResponse}}
         done();
       });
     });

--- a/templates/supertest/get/get.handlebars
+++ b/templates/supertest/get/get.handlebars
@@ -16,9 +16,7 @@
       {{/if}}
       .expect({{responseCode}})
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         {{#validateResponse returnType noSchema}}
         {{#is ../assertion 'expect'}}

--- a/templates/supertest/post/post.handlebars
+++ b/templates/supertest/post/post.handlebars
@@ -37,9 +37,7 @@
       {{/is}}
       .expect({{responseCode}})
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         {{#validateResponse returnType noSchema}}
         {{#is ../assertion 'expect'}}

--- a/templates/supertest/post/post.handlebars
+++ b/templates/supertest/post/post.handlebars
@@ -1,10 +1,10 @@
   it('should respond with {{description}}', function(done) {
-      {{#unless noSchema}}
+      {{#validateResponse returnType noSchema}}
       /*eslint-disable*/
       {{> schema-partial this}}
 
       /*eslint-enable*/
-      {{/unless}}
+      {{/validateResponse}}
       api.post('{{path}}')
       .set('Accept', '{{contentType}}')
       {{#if headerParameters}}
@@ -40,30 +40,28 @@
         if (err) {
           return done(err);
         }
-        {{#if noSchema}}
-            {{#is ../assertion 'expect'}}
-        expect(res).to.equal(null);
-            {{/is}}
-            {{#is ../assertion 'should'}}
-        res.should.equal(null);
-            {{/is}}
-            {{#is ../assertion 'assert'}}
-        assert.isNull(res);
-            {{/is}}
-        {{/if}}
-        {{#unless noSchema}}
-            {{#is ../assertion 'expect'}}
-        expect(validator.validate(res, schema)).to.be.true;
 
-            {{/is}}
-            {{#is ../assertion 'should'}}
-        validator.validate(res, schema).should.be.true;
-
-            {{/is}}
-            {{#is ../assertion 'assert'}}
-        assert.true(validator.validate(res, schema));
-            {{/is}}
-        {{/unless}}
+        {{#validateResponse returnType noSchema}}
+        {{#is ../assertion 'expect'}}
+        expect(validator.validate(res.body, schema)).to.be.true;
+        {{/is}}
+        {{#is ../assertion 'should'}}
+        validator.validate(res.body, schema).should.be.true;
+        {{/is}}
+        {{#is ../assertion 'assert'}}
+        assert.true(validator.validate(res.body, schema));
+        {{/is}}
+        {{else}}
+        {{#is ../assertion 'expect'}}
+        expect(res.body).to.equal(null); // non-json response or no schema
+        {{/is}}
+        {{#is ../assertion 'should'}}
+        res.body.should.equal(null); // non-json response or no schema
+        {{/is}}
+        {{#is ../assertion 'assert'}}
+        assert.isNull(res.body); // non-json response or no schema
+        {{/is}}
+        {{/validateResponse}}
         done();
       });
     });

--- a/templates/supertest/put/put.handlebars
+++ b/templates/supertest/put/put.handlebars
@@ -1,10 +1,10 @@
   it('should respond with {{description}}', function(done) {
-      {{#unless noSchema}}
+      {{#validateResponse returnType noSchema}}
       /*eslint-disable*/
       {{> schema-partial this}}
 
       /*eslint-enable*/
-      {{/unless}}
+      {{/validateResponse}}
       api.put('{{path}}')
       .set('Accept', '{{contentType}}')
       {{#if headerParameters}}
@@ -40,30 +40,28 @@
         if (err) {
           return done(err);
         }
-        {{#if noSchema}}
-            {{#is ../assertion 'expect'}}
-        expect(res).to.equal(null);
-            {{/is}}
-            {{#is ../assertion 'should'}}
-        res.should.equal(null);
-            {{/is}}
-            {{#is ../assertion 'assert'}}
-        assert.isNull(res);
-            {{/is}}
-        {{/if}}
-        {{#unless noSchema}}
-            {{#is ../assertion 'expect'}}
-        expect(validator.validate(res, schema)).to.be.true;
 
-            {{/is}}
-            {{#is ../assertion 'should'}}
-        validator.validate(res, schema).should.be.true;
-
-            {{/is}}
-            {{#is ../assertion 'assert'}}
-        assert.true(validator.validate(res, schema));
-            {{/is}}
-        {{/unless}}
+        {{#validateResponse returnType noSchema}}
+        {{#is ../assertion 'expect'}}
+        expect(validator.validate(res.body, schema)).to.be.true;
+        {{/is}}
+        {{#is ../assertion 'should'}}
+        validator.validate(res.body, schema).should.be.true;
+        {{/is}}
+        {{#is ../assertion 'assert'}}
+        assert.true(validator.validate(res.body, schema));
+        {{/is}}
+        {{else}}
+        {{#is ../assertion 'expect'}}
+        expect(res.body).to.equal(null); // non-json response or no schema
+        {{/is}}
+        {{#is ../assertion 'should'}}
+        res.body.should.equal(null); // non-json response or no schema
+        {{/is}}
+        {{#is ../assertion 'assert'}}
+        assert.isNull(res.body); // non-json response or no schema
+        {{/is}}
+        {{/validateResponse}}
         done();
       });
     });

--- a/templates/supertest/put/put.handlebars
+++ b/templates/supertest/put/put.handlebars
@@ -37,9 +37,7 @@
       {{/is}}
       .expect({{responseCode}})
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         {{#validateResponse returnType noSchema}}
         {{#is ../assertion 'expect'}}

--- a/test/cascading/test.js
+++ b/test/cascading/test.js
@@ -63,10 +63,6 @@ describe('Test getData function', function() {
       expect(data.bodyParameters).to.have.length(1);
       expect(data).to.have.property('queryParameters');
       expect(data.queryParameters).to.have.length(1);
-      expect(data).to.have.property('contentType');
-      expect(data.contentType).to.equal('application/json');
-      expect(data).to.have.property('returnType');
-      expect(data.returnType).to.equal('application/json');
       expect(data).to.have.property('path');
       expect(data.path).to.equal('/plan?data=DATA');
       done();
@@ -79,10 +75,6 @@ describe('Test getData function', function() {
 
       expect(data).to.have.property('pathParameters');
       expect(data.pathParameters).to.have.length(1);
-      expect(data).to.have.property('contentType');
-      expect(data.contentType).to.equal('application/json');
-      expect(data).to.have.property('returnType');
-      expect(data.returnType).to.equal('application/json');
       expect(data).to.have.property('path');
       expect(data.path).to.equal('/plan/{plan_id}/users');
       done();
@@ -96,10 +88,6 @@ describe('Test getData function', function() {
       expect(data.bodyParameters).to.have.length(1);
       expect(data).to.have.property('queryParameters');
       expect(data.queryParameters).to.have.length(2);
-      expect(data).to.have.property('contentType');
-      expect(data.contentType).to.equal('application/json');
-      expect(data).to.have.property('returnType');
-      expect(data.returnType).to.equal('application/json');
       expect(data).to.have.property('path');
       expect(data.path).to.equal('/user?name=DATA&time=DATA');
       done();
@@ -116,10 +104,6 @@ describe('Test getData function', function() {
       expect(data.bodyParameters).to.have.length(1);
       expect(data).to.have.property('queryParameters');
       expect(data.queryParameters).to.have.length(1);
-      expect(data).to.have.property('contentType');
-      expect(data.contentType).to.equal('application/json');
-      expect(data).to.have.property('returnType');
-      expect(data.returnType).to.equal('application/json');
       expect(data).to.have.property('path');
       expect(data.path).to.equal('http://localhost:10010/plan');
       done();
@@ -132,10 +116,6 @@ describe('Test getData function', function() {
 
       expect(data).to.have.property('pathParameters');
       expect(data.pathParameters).to.have.length(1);
-      expect(data).to.have.property('contentType');
-      expect(data.contentType).to.equal('application/json');
-      expect(data).to.have.property('returnType');
-      expect(data.returnType).to.equal('application/json');
       expect(data).to.have.property('path');
       expect(data.path).to.equal('http://localhost:10010/plan/{plan_id}/users');
       done();
@@ -149,10 +129,6 @@ describe('Test getData function', function() {
       expect(data.bodyParameters).to.have.length(1);
       expect(data).to.have.property('queryParameters');
       expect(data.queryParameters).to.have.length(2);
-      expect(data).to.have.property('contentType');
-      expect(data.contentType).to.equal('application/json');
-      expect(data).to.have.property('returnType');
-      expect(data.returnType).to.equal('application/json');
       expect(data).to.have.property('path');
       expect(data.path).to.equal('http://localhost:10010/user');
       done();

--- a/test/cascading/test.js
+++ b/test/cascading/test.js
@@ -56,7 +56,7 @@ describe('Test getData function', function() {
   describe('Test swagger with config1', function() {
 
     it('should get all the data parsed for the /plan',
-      function(done) {
+      function() {
       var data = getData(swagger, '/plan', 'post', '200', config1);
 
       expect(data).to.have.property('bodyParameters');
@@ -65,11 +65,10 @@ describe('Test getData function', function() {
       expect(data.queryParameters).to.have.length(1);
       expect(data).to.have.property('path');
       expect(data.path).to.equal('/plan?data=DATA');
-      done();
     });
 
     it('should get all the data parsed for the /plan/{plan_id}/users',
-      function(done) {
+      function() {
       var data = getData(swagger,
         '/plan/{plan_id}/users', 'get', '200', config1);
 
@@ -77,11 +76,10 @@ describe('Test getData function', function() {
       expect(data.pathParameters).to.have.length(1);
       expect(data).to.have.property('path');
       expect(data.path).to.equal('/plan/{plan_id}/users');
-      done();
     });
 
     it('should get all the data parsed for the /user post',
-      function(done) {
+      function() {
       var data = getData(swagger, '/user', 'post', '200', config1);
 
       expect(data).to.have.property('bodyParameters');
@@ -90,14 +88,13 @@ describe('Test getData function', function() {
       expect(data.queryParameters).to.have.length(2);
       expect(data).to.have.property('path');
       expect(data.path).to.equal('/user?name=DATA&time=DATA');
-      done();
     });
   });
 
   describe('Test swagger with config2', function() {
 
     it('should get all the data parsed for the /plan',
-      function(done) {
+      function() {
       var data = getData(swagger, '/plan', 'post', '200', config2);
 
       expect(data).to.have.property('bodyParameters');
@@ -106,11 +103,10 @@ describe('Test getData function', function() {
       expect(data.queryParameters).to.have.length(1);
       expect(data).to.have.property('path');
       expect(data.path).to.equal('http://localhost:10010/plan');
-      done();
     });
 
     it('should get all the data parsed for the /plan/{plan_id}/users',
-      function(done) {
+      function() {
       var data = getData(swagger,
         '/plan/{plan_id}/users', 'get', '200', config2);
 
@@ -118,11 +114,10 @@ describe('Test getData function', function() {
       expect(data.pathParameters).to.have.length(1);
       expect(data).to.have.property('path');
       expect(data.path).to.equal('http://localhost:10010/plan/{plan_id}/users');
-      done();
     });
 
     it('should get all the data parsed for the /user post',
-      function(done) {
+      function() {
       var data = getData(swagger, '/user', 'post', '200', config2);
 
       expect(data).to.have.property('bodyParameters');
@@ -131,7 +126,6 @@ describe('Test getData function', function() {
       expect(data.queryParameters).to.have.length(2);
       expect(data).to.have.property('path');
       expect(data.path).to.equal('http://localhost:10010/user');
-      done();
     });
   });
 });

--- a/test/minimal/compare/output10__Stub.js
+++ b/test/minimal/compare/output10__Stub.js
@@ -1,0 +1,38 @@
+'use strict';
+var chai = require('chai');
+
+chai.should();
+var supertest = require('supertest');
+var api = supertest('http://localhost:10010'); // supertest init;
+
+describe('/', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      api.get('/')
+      .set('Accept', 'application/xml')
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        res.body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+    it('should respond with 200 OK', function(done) {
+      api.get('/')
+      .set('Accept', 'application/json')
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        res.body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+  });
+
+});

--- a/test/minimal/compare/output10__Stub.js
+++ b/test/minimal/compare/output10__Stub.js
@@ -12,9 +12,7 @@ describe('/', function() {
       .set('Accept', 'application/xml')
       .expect(200)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         res.body.should.equal(null); // non-json response or no schema
         done();
@@ -25,9 +23,7 @@ describe('/', function() {
       .set('Accept', 'application/json')
       .expect(200)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         res.body.should.equal(null); // non-json response or no schema
         done();

--- a/test/minimal/compare/output11__Stub.js
+++ b/test/minimal/compare/output11__Stub.js
@@ -1,0 +1,38 @@
+'use strict';
+var chai = require('chai');
+
+chai.should();
+var supertest = require('supertest');
+var api = supertest('http://localhost:10010'); // supertest init;
+
+describe('/', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      api.get('/')
+      .set('Accept', 'application/xml')
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        res.body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+    it('should respond with 200 OK', function(done) {
+      api.get('/')
+      .set('Accept', 'application/json')
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        res.body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+  });
+
+});

--- a/test/minimal/compare/output11__Stub.js
+++ b/test/minimal/compare/output11__Stub.js
@@ -12,9 +12,7 @@ describe('/', function() {
       .set('Accept', 'application/xml')
       .expect(200)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         res.body.should.equal(null); // non-json response or no schema
         done();
@@ -25,9 +23,7 @@ describe('/', function() {
       .set('Accept', 'application/json')
       .expect(200)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         res.body.should.equal(null); // non-json response or no schema
         done();

--- a/test/minimal/compare/output12__Stub.js
+++ b/test/minimal/compare/output12__Stub.js
@@ -12,9 +12,7 @@ describe('/', function() {
       .set('Accept', 'application/xml')
       .expect(200)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         res.body.should.equal(null); // non-json response or no schema
         done();
@@ -25,9 +23,7 @@ describe('/', function() {
       .set('Accept', 'application/xml')
       .expect(200)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         res.body.should.equal(null); // non-json response or no schema
         done();
@@ -38,9 +34,7 @@ describe('/', function() {
       .set('Accept', 'application/json')
       .expect(200)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         res.body.should.equal(null); // non-json response or no schema
         done();
@@ -51,9 +45,7 @@ describe('/', function() {
       .set('Accept', 'application/json')
       .expect(200)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         res.body.should.equal(null); // non-json response or no schema
         done();

--- a/test/minimal/compare/output12__Stub.js
+++ b/test/minimal/compare/output12__Stub.js
@@ -1,0 +1,64 @@
+'use strict';
+var chai = require('chai');
+
+chai.should();
+var supertest = require('supertest');
+var api = supertest('http://localhost:10010'); // supertest init;
+
+describe('/', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      api.get('/')
+      .set('Accept', 'application/xml')
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        res.body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+    it('should respond with 200 OK', function(done) {
+      api.get('/')
+      .set('Accept', 'application/xml')
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        res.body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+    it('should respond with 200 OK', function(done) {
+      api.get('/')
+      .set('Accept', 'application/json')
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        res.body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+    it('should respond with 200 OK', function(done) {
+      api.get('/')
+      .set('Accept', 'application/json')
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        res.body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+  });
+
+});

--- a/test/minimal/compare/output13__Stub.js
+++ b/test/minimal/compare/output13__Stub.js
@@ -12,9 +12,7 @@ describe('/', function() {
       .set('Accept', 'application/json')
       .expect(200)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         res.body.should.equal(null); // non-json response or no schema
         done();
@@ -25,9 +23,7 @@ describe('/', function() {
       .set('Accept', 'application/json')
       .expect(200)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         res.body.should.equal(null); // non-json response or no schema
         done();

--- a/test/minimal/compare/output13__Stub.js
+++ b/test/minimal/compare/output13__Stub.js
@@ -1,0 +1,38 @@
+'use strict';
+var chai = require('chai');
+
+chai.should();
+var supertest = require('supertest');
+var api = supertest('http://localhost:10010'); // supertest init;
+
+describe('/', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      api.get('/')
+      .set('Accept', 'application/json')
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        res.body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+    it('should respond with 200 OK', function(done) {
+      api.get('/')
+      .set('Accept', 'application/json')
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        res.body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+  });
+
+});

--- a/test/minimal/compare/output14__Stub.js
+++ b/test/minimal/compare/output14__Stub.js
@@ -1,0 +1,49 @@
+'use strict';
+var chai = require('chai');
+
+chai.should();
+var request = require('request');
+
+describe('/', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      request({
+        url: 'http://localhost:10010/',
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(200);
+
+        body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 200 OK', function(done) {
+      request({
+        url: 'http://localhost:10010/',
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(200);
+
+        body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/minimal/compare/output14__Stub.js
+++ b/test/minimal/compare/output14__Stub.js
@@ -15,9 +15,8 @@ describe('/', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(200);
 
         body.should.equal(null); // non-json response or no schema
@@ -34,9 +33,8 @@ describe('/', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(200);
 
         body.should.equal(null); // non-json response or no schema

--- a/test/minimal/compare/output15__Stub.js
+++ b/test/minimal/compare/output15__Stub.js
@@ -15,9 +15,8 @@ describe('/', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(200);
 
         body.should.equal(null); // non-json response or no schema
@@ -34,9 +33,8 @@ describe('/', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(200);
 
         body.should.equal(null); // non-json response or no schema
@@ -53,9 +51,8 @@ describe('/', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(200);
 
         body.should.equal(null); // non-json response or no schema
@@ -72,9 +69,8 @@ describe('/', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(200);
 
         body.should.equal(null); // non-json response or no schema

--- a/test/minimal/compare/output15__Stub.js
+++ b/test/minimal/compare/output15__Stub.js
@@ -1,0 +1,87 @@
+'use strict';
+var chai = require('chai');
+
+chai.should();
+var request = require('request');
+
+describe('/', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      request({
+        url: 'http://localhost:10010/',
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/xml'
+        }
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(200);
+
+        body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 200 OK', function(done) {
+      request({
+        url: 'http://localhost:10010/',
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/xml'
+        }
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(200);
+
+        body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 200 OK', function(done) {
+      request({
+        url: 'http://localhost:10010/',
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(200);
+
+        body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 200 OK', function(done) {
+      request({
+        url: 'http://localhost:10010/',
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(200);
+
+        body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/minimal/compare/output16__Stub.js
+++ b/test/minimal/compare/output16__Stub.js
@@ -1,0 +1,49 @@
+'use strict';
+var chai = require('chai');
+
+chai.should();
+var request = require('request');
+
+describe('/', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      request({
+        url: 'http://localhost:10010/',
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/xml'
+        }
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(200);
+
+        body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 200 OK', function(done) {
+      request({
+        url: 'http://localhost:10010/',
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(200);
+
+        body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/minimal/compare/output16__Stub.js
+++ b/test/minimal/compare/output16__Stub.js
@@ -15,9 +15,8 @@ describe('/', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(200);
 
         body.should.equal(null); // non-json response or no schema
@@ -34,9 +33,8 @@ describe('/', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(200);
 
         body.should.equal(null); // non-json response or no schema

--- a/test/minimal/compare/output17__Stub.js
+++ b/test/minimal/compare/output17__Stub.js
@@ -1,0 +1,49 @@
+'use strict';
+var chai = require('chai');
+
+chai.should();
+var request = require('request');
+
+describe('/', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      request({
+        url: 'http://localhost:10010/',
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/xml'
+        }
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(200);
+
+        body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 200 OK', function(done) {
+      request({
+        url: 'http://localhost:10010/',
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(200);
+
+        body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/minimal/compare/output17__Stub.js
+++ b/test/minimal/compare/output17__Stub.js
@@ -15,9 +15,8 @@ describe('/', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(200);
 
         body.should.equal(null); // non-json response or no schema
@@ -34,9 +33,8 @@ describe('/', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(200);
 
         body.should.equal(null); // non-json response or no schema

--- a/test/minimal/compare/output18__Stub.js
+++ b/test/minimal/compare/output18__Stub.js
@@ -15,9 +15,8 @@ describe('/', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(200);
 
         body.should.equal(null); // non-json response or no schema

--- a/test/minimal/compare/output18__Stub.js
+++ b/test/minimal/compare/output18__Stub.js
@@ -1,0 +1,30 @@
+'use strict';
+var chai = require('chai');
+
+chai.should();
+var request = require('request');
+
+describe('/', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      request({
+        url: 'http://localhost:10010/',
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/xml'
+        }
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(200);
+
+        body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/minimal/compare/output1__Stub.js
+++ b/test/minimal/compare/output1__Stub.js
@@ -15,9 +15,8 @@ describe('/', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(200);
 
         body.should.equal(null); // non-json response or no schema

--- a/test/minimal/compare/output1__Stub.js
+++ b/test/minimal/compare/output1__Stub.js
@@ -18,7 +18,9 @@ describe('/', function() {
         if (error) {
           return done(error);
         }
-        body.should.equal(null);
+        res.statusCode.should.equal(200);
+
+        body.should.equal(null); // non-json response or no schema
         done();
       });
     });

--- a/test/minimal/compare/output2__Stub.js
+++ b/test/minimal/compare/output2__Stub.js
@@ -15,9 +15,8 @@ describe('/', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(200);
 
         body.should.equal(null); // non-json response or no schema

--- a/test/minimal/compare/output2__Stub.js
+++ b/test/minimal/compare/output2__Stub.js
@@ -18,7 +18,9 @@ describe('/', function() {
         if (error) {
           return done(error);
         }
-        body.should.equal(null);
+        res.statusCode.should.equal(200);
+
+        body.should.equal(null); // non-json response or no schema
         done();
       });
     });

--- a/test/minimal/compare/output3__Stub.js
+++ b/test/minimal/compare/output3__Stub.js
@@ -12,9 +12,7 @@ describe('/', function() {
       .set('Accept', 'application/json')
       .expect(200)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         res.body.should.equal(null); // non-json response or no schema
         done();

--- a/test/minimal/compare/output3__Stub.js
+++ b/test/minimal/compare/output3__Stub.js
@@ -15,8 +15,8 @@ describe('/', function() {
         if (err) {
           return done(err);
         }
-        res.should.equal(null);
-        res.should.have.property('name');
+
+        res.body.should.equal(null); // non-json response or no schema
         done();
       });
     });

--- a/test/minimal/compare/output4__Stub.js
+++ b/test/minimal/compare/output4__Stub.js
@@ -12,9 +12,7 @@ describe('/', function() {
       .set('Accept', 'application/json')
       .expect(200)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         res.body.should.equal(null); // non-json response or no schema
         done();

--- a/test/minimal/compare/output4__Stub.js
+++ b/test/minimal/compare/output4__Stub.js
@@ -15,8 +15,8 @@ describe('/', function() {
         if (err) {
           return done(err);
         }
-        res.should.equal(null);
-        res.should.have.property('name');
+
+        res.body.should.equal(null); // non-json response or no schema
         done();
       });
     });

--- a/test/minimal/compare/output5__Stub.js
+++ b/test/minimal/compare/output5__Stub.js
@@ -14,9 +14,8 @@ describe('/', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         assert.equal(res.statusCode, 200);
 
         assert.isNull(body); // non-json response or no schema

--- a/test/minimal/compare/output5__Stub.js
+++ b/test/minimal/compare/output5__Stub.js
@@ -17,7 +17,9 @@ describe('/', function() {
         if (error) {
           return done(error);
         }
-        assert.isNull(body);
+        assert.equal(res.statusCode, 200);
+
+        assert.isNull(body); // non-json response or no schema
         done();
       });
     });

--- a/test/minimal/compare/output6__Stub.js
+++ b/test/minimal/compare/output6__Stub.js
@@ -17,7 +17,9 @@ describe('/', function() {
         if (error) {
           return done(error);
         }
-        expect(body).to.equal(null);
+        expect(res.statusCode).to.equal(200);
+
+        expect(body).to.equal(null); // non-json response or no schema
         done();
       });
     });

--- a/test/minimal/compare/output6__Stub.js
+++ b/test/minimal/compare/output6__Stub.js
@@ -14,9 +14,8 @@ describe('/', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         expect(res.statusCode).to.equal(200);
 
         expect(body).to.equal(null); // non-json response or no schema

--- a/test/minimal/compare/output7__Stub.js
+++ b/test/minimal/compare/output7__Stub.js
@@ -11,9 +11,7 @@ describe('/', function() {
       .set('Accept', 'application/json')
       .expect(200)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         assert.isNull(res.body); // non-json response or no schema
         done();

--- a/test/minimal/compare/output7__Stub.js
+++ b/test/minimal/compare/output7__Stub.js
@@ -14,8 +14,8 @@ describe('/', function() {
         if (err) {
           return done(err);
         }
-        assert.isNull(res);
-        assert.property(res, 'name');
+
+        assert.isNull(res.body); // non-json response or no schema
         done();
       });
     });

--- a/test/minimal/compare/output8__Stub.js
+++ b/test/minimal/compare/output8__Stub.js
@@ -14,8 +14,8 @@ describe('/', function() {
         if (err) {
           return done(err);
         }
-        expect(res).to.equal(null);
-        expect(res).to.have.property('name');
+
+        expect(res.body).to.equal(null); // non-json response or no schema
         done();
       });
     });

--- a/test/minimal/compare/output8__Stub.js
+++ b/test/minimal/compare/output8__Stub.js
@@ -11,9 +11,7 @@ describe('/', function() {
       .set('Accept', 'application/json')
       .expect(200)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         expect(res.body).to.equal(null); // non-json response or no schema
         done();

--- a/test/minimal/compare/output9__Stub.js
+++ b/test/minimal/compare/output9__Stub.js
@@ -1,0 +1,25 @@
+'use strict';
+var chai = require('chai');
+
+chai.should();
+var supertest = require('supertest');
+var api = supertest('http://localhost:10010'); // supertest init;
+
+describe('/', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      api.get('/')
+      .set('Accept', 'application/xml')
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        res.body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+  });
+
+});

--- a/test/minimal/compare/output9__Stub.js
+++ b/test/minimal/compare/output9__Stub.js
@@ -12,9 +12,7 @@ describe('/', function() {
       .set('Accept', 'application/xml')
       .expect(200)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         res.body.should.equal(null); // non-json response or no schema
         done();

--- a/test/minimal/test.js
+++ b/test/minimal/test.js
@@ -182,6 +182,205 @@ describe('minimal swagger', function() {
         }
       });
     });
+
+    describe('consumes', function() {
+      swagger.consumes = ['application/xml'];
+
+      var output18 = testGen(swagger, {
+        assertionFormat: 'should',
+        pathName: [],
+        testModule: 'request'
+      });
+
+      var paths18 = [];
+      var ndx;
+
+      for (ndx in output18) {
+        if (paths18 !== undefined) {
+          paths18.push(join(__dirname, '/compare/output18'
+            + output18[ndx].name));
+        }
+      }
+
+      it('should generate all paths with \'xml\' comsumes', function() {
+
+        assert.isArray(output18);
+        assert.lengthOf(output18, 1);
+
+        var generatedCode;
+
+        for (ndx in paths18) {
+          if (paths18 !== undefined) {
+            generatedCode = read(paths18[ndx], 'utf8');
+            assert.equal(output18[ndx].test, generatedCode);
+          }
+        }
+
+        for (ndx in output18) {
+          if (output18 !== undefined) {
+            assert.lengthOf(linter.verify(output18[ndx].test, rules), 0);
+          }
+        }
+      });
+
+      swagger.consumes.push('application/json');
+
+      var output17 = testGen(swagger, {
+        assertionFormat: 'should',
+        pathName: [],
+        testModule: 'request'
+      });
+
+      var paths17 = [];
+
+      for (ndx in output17) {
+        if (output17[ndx] !== undefined) {
+          paths17.push(join(__dirname, '/compare/output17'
+            + output17[ndx].name));
+        }
+      }
+
+      it('should generate paths with \'xml\' & \'json\' comsumes', function() {
+
+        assert.isArray(output17);
+        assert.lengthOf(output17, 1);
+
+        var generatedCode;
+
+        for (ndx in paths17) {
+          if (paths17[ndx] !== undefined) {
+            generatedCode = read(paths17[ndx], 'utf8');
+            assert.equal(output17[ndx].test, generatedCode);
+          }
+        }
+
+        for (ndx in output17) {
+          if (output17 !== undefined) {
+            assert.lengthOf(linter.verify(output17[ndx].test, rules), 0);
+          }
+        }
+      });
+    });
+
+    describe('produces', function() {
+      swagger.produces = ['application/xml'];
+
+      var output16 = testGen(swagger, {
+        assertionFormat: 'should',
+        pathName: [],
+        testModule: 'request'
+      });
+
+      var paths16 = [];
+      var ndx;
+
+      for (ndx in output16) {
+        if (output16[ndx] !== undefined) {
+          paths16.push(join(__dirname, '/compare/output16'
+            + output16[ndx].name));
+        }
+      }
+
+      it('should generate paths w/all consumes and produces xml', function() {
+
+        assert.isArray(output16);
+        assert.lengthOf(output16, 1);
+
+        var generatedCode;
+
+        for (ndx in paths16) {
+          if (paths16[ndx] !== undefined) {
+            generatedCode = read(paths16[ndx], 'utf8');
+            assert.equal(output16[ndx].test, generatedCode);
+          }
+        }
+
+        for (ndx in output16) {
+          if (output16 !== undefined) {
+            assert.lengthOf(linter.verify(output16[ndx].test, rules), 0);
+          }
+        }
+      });
+
+      swagger.produces.push('application/json');
+
+      var output15 = testGen(swagger, {
+        assertionFormat: 'should',
+        pathName: [],
+        testModule: 'request'
+      });
+
+      var paths15 = [];
+
+      for (ndx in output15) {
+        if (output15[ndx] !== undefined) {
+          paths15.push(join(__dirname, '/compare/output15'
+            + output15[ndx].name));
+        }
+      }
+
+      it('should generate paths w/all consumes and all produces', function() {
+
+        assert.isArray(output15);
+        assert.lengthOf(output15, 1);
+
+        var generatedCode;
+
+        for (ndx in paths15) {
+          if (paths15[ndx] !== undefined) {
+            generatedCode = read(paths15[ndx], 'utf8');
+            assert.equal(output15[ndx].test, generatedCode);
+          }
+        }
+
+        for (ndx in output15) {
+          if (output15 !== undefined) {
+            assert.lengthOf(linter.verify(output15[ndx].test, rules), 0);
+          }
+        }
+      });
+
+      swagger.consumes = [];
+
+      var output14 = testGen(swagger, {
+        assertionFormat: 'should',
+        pathName: [],
+        testModule: 'request'
+      });
+
+      var paths14 = [];
+
+      for (ndx in output14) {
+        if (output14[ndx] !== undefined) {
+          paths14.push(join(__dirname, '/compare/output14'
+            + output14[ndx].name));
+        }
+      }
+
+      it('should generate paths w/default consumes & produces', function() {
+
+        assert.isArray(output14);
+        assert.lengthOf(output14, 1);
+
+        var generatedCode;
+
+        for (ndx in paths14) {
+          if (paths14[ndx] !== undefined) {
+            generatedCode = read(paths14[ndx], 'utf8');
+            assert.equal(output14[ndx].test, generatedCode);
+          }
+        }
+
+        for (ndx in output14) {
+          if (output14 !== undefined) {
+            assert.lengthOf(linter.verify(output14[ndx].test, rules), 0);
+          }
+        }
+      });
+
+      swagger.consumes = [];
+      swagger.produces = [];
+    });
   });
 
   describe('supertest-option', function() {
@@ -327,6 +526,201 @@ describe('minimal swagger', function() {
         for (ndx in output8) {
           if (output8 !== undefined) {
             assert.lengthOf(linter.verify(output8[ndx].test, rules), 0);
+          }
+        }
+      });
+    });
+
+    describe('consumes', function() {
+      swagger.consumes = ['application/xml'];
+
+      var output9 = testGen(swagger, {
+        assertionFormat: 'should',
+        pathName: [],
+        testModule: 'supertest'
+      });
+
+      var paths9 = [];
+      var ndx;
+
+      for (ndx in output9) {
+        if (paths9 !== undefined) {
+          paths9.push(join(__dirname, '/compare/output9' + output9[ndx].name));
+        }
+      }
+
+      it('should generate all paths with \'xml\' comsumes', function() {
+
+        assert.isArray(output9);
+        assert.lengthOf(output9, 1);
+
+        var generatedCode;
+
+        for (ndx in paths9) {
+          if (paths9 !== undefined) {
+            generatedCode = read(paths9[ndx], 'utf8');
+            assert.equal(output9[ndx].test, generatedCode);
+          }
+        }
+
+        for (ndx in output9) {
+          if (output9 !== undefined) {
+            assert.lengthOf(linter.verify(output9[ndx].test, rules), 0);
+          }
+        }
+      });
+
+      swagger.consumes.push('application/json');
+
+      var output10 = testGen(swagger, {
+        assertionFormat: 'should',
+        pathName: [],
+        testModule: 'supertest'
+      });
+
+      var paths10 = [];
+
+      for (ndx in output10) {
+        if (output10[ndx] !== undefined) {
+          paths10.push(join(__dirname, '/compare/output10'
+            + output10[ndx].name));
+        }
+      }
+
+      it('should generate paths with \'xml\' & \'json\' comsumes', function() {
+
+        assert.isArray(output10);
+        assert.lengthOf(output10, 1);
+
+        var generatedCode;
+
+        for (ndx in paths10) {
+          if (paths10[ndx] !== undefined) {
+            generatedCode = read(paths10[ndx], 'utf8');
+            assert.equal(output10[ndx].test, generatedCode);
+          }
+        }
+
+        for (ndx in output10) {
+          if (output10 !== undefined) {
+            assert.lengthOf(linter.verify(output10[ndx].test, rules), 0);
+          }
+        }
+      });
+    });
+
+    describe('produces', function() {
+      swagger.produces = ['application/xml'];
+
+      var output11 = testGen(swagger, {
+        assertionFormat: 'should',
+        pathName: [],
+        testModule: 'supertest'
+      });
+
+      var paths11 = [];
+      var ndx;
+
+      for (ndx in output11) {
+        if (output11[ndx] !== undefined) {
+          paths11.push(join(__dirname, '/compare/output11'
+            + output11[ndx].name));
+        }
+      }
+
+      it('should generate paths w/all consumes & produces xml', function() {
+
+        assert.isArray(output11);
+        assert.lengthOf(output11, 1);
+
+        var generatedCode;
+
+        for (ndx in paths11) {
+          if (paths11[ndx] !== undefined) {
+            generatedCode = read(paths11[ndx], 'utf8');
+            assert.equal(output11[ndx].test, generatedCode);
+          }
+        }
+
+        for (ndx in output11) {
+          if (output11 !== undefined) {
+            assert.lengthOf(linter.verify(output11[ndx].test, rules), 0);
+          }
+        }
+      });
+
+      swagger.produces.push('application/json');
+
+      var output12 = testGen(swagger, {
+        assertionFormat: 'should',
+        pathName: [],
+        testModule: 'supertest'
+      });
+
+      var paths12 = [];
+
+      for (ndx in output12) {
+        if (output12[ndx] !== undefined) {
+          paths12.push(join(__dirname, '/compare/output12'
+            + output12[ndx].name));
+        }
+      }
+
+      it('should generate paths w/all consumes and all produces', function() {
+
+        assert.isArray(output12);
+        assert.lengthOf(output12, 1);
+
+        var generatedCode;
+
+        for (ndx in paths12) {
+          if (paths12[ndx] !== undefined) {
+            generatedCode = read(paths12[ndx], 'utf8');
+            assert.equal(output12[ndx].test, generatedCode);
+          }
+        }
+
+        for (ndx in output12) {
+          if (output12 !== undefined) {
+            assert.lengthOf(linter.verify(output12[ndx].test, rules), 0);
+          }
+        }
+      });
+
+      swagger.consumes = [];
+
+      var output13 = testGen(swagger, {
+        assertionFormat: 'should',
+        pathName: [],
+        testModule: 'supertest'
+      });
+
+      var paths13 = [];
+
+      for (ndx in output13) {
+        if (output13[ndx] !== undefined) {
+          paths13.push(join(__dirname, '/compare/output13'
+            + output13[ndx].name));
+        }
+      }
+
+      it('should generate paths w/default consumes & all produces', function() {
+
+        assert.isArray(output13);
+        assert.lengthOf(output13, 1);
+
+        var generatedCode;
+
+        for (ndx in paths13) {
+          if (paths13[ndx] !== undefined) {
+            generatedCode = read(paths13[ndx], 'utf8');
+            assert.equal(output13[ndx].test, generatedCode);
+          }
+        }
+
+        for (ndx in output13) {
+          if (output13 !== undefined) {
+            assert.lengthOf(linter.verify(output13[ndx].test, rules), 0);
           }
         }
       });

--- a/test/robust/compare/output10__Stub.js
+++ b/test/robust/compare/output10__Stub.js
@@ -27,9 +27,7 @@ describe('/', function() {
       .set('Accept', 'application/xml')
       .expect(200)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         validator.validate(res.body, schema).should.be.true;
         done();
@@ -53,9 +51,7 @@ describe('/', function() {
       .set('Accept', 'application/json')
       .expect(200)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         validator.validate(res.body, schema).should.be.true;
         done();
@@ -75,9 +71,7 @@ describe('/', function() {
       .set('Accept', 'application/xml')
       .expect(400)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         validator.validate(res.body, schema).should.be.true;
         done();
@@ -97,9 +91,7 @@ describe('/', function() {
       .set('Accept', 'application/json')
       .expect(400)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         validator.validate(res.body, schema).should.be.true;
         done();
@@ -131,9 +123,7 @@ describe('/', function() {
       .set('Accept', 'application/xml')
       .expect(500)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         validator.validate(res.body, schema).should.be.true;
         done();
@@ -165,9 +155,7 @@ describe('/', function() {
       .set('Accept', 'application/json')
       .expect(500)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         validator.validate(res.body, schema).should.be.true;
         done();
@@ -197,9 +185,7 @@ describe('/', function() {
       .set('Accept', 'application/xml')
       .expect(200)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         validator.validate(res.body, schema).should.be.true;
         done();
@@ -230,9 +216,7 @@ describe('/', function() {
       })
       .expect(200)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         validator.validate(res.body, schema).should.be.true;
         done();
@@ -249,9 +233,7 @@ describe('/', function() {
       .set('Accept', 'application/xml')
       .expect(400)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         validator.validate(res.body, schema).should.be.true;
         done();
@@ -271,9 +253,7 @@ describe('/', function() {
       })
       .expect(400)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         validator.validate(res.body, schema).should.be.true;
         done();
@@ -290,9 +270,7 @@ describe('/', function() {
       .set('Accept', 'application/xml')
       .expect(500)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         validator.validate(res.body, schema).should.be.true;
         done();
@@ -312,9 +290,7 @@ describe('/', function() {
       })
       .expect(500)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         validator.validate(res.body, schema).should.be.true;
         done();

--- a/test/robust/compare/output10__Stub.js
+++ b/test/robust/compare/output10__Stub.js
@@ -1,0 +1,326 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+
+chai.should();
+var supertest = require('supertest');
+var api = supertest('https://api.uber.com'); // supertest init;
+
+describe('/', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "username": {
+            "type": "string"
+          }
+        }
+      };
+      /*eslint-enable*/
+      api.get('/')
+      .set('Accept', 'application/xml')
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        validator.validate(res.body, schema).should.be.true;
+        done();
+      });
+    });
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "username": {
+            "type": "string"
+          }
+        }
+      };
+      /*eslint-enable*/
+      api.get('/')
+      .set('Accept', 'application/json')
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        validator.validate(res.body, schema).should.be.true;
+        done();
+      });
+    });
+    it('should respond with 400 NOT OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "properties": {
+          "meta": "string",
+          "data": "number"
+        }
+      };
+      /*eslint-enable*/
+      api.get('/')
+      .set('Accept', 'application/xml')
+      .expect(400)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        validator.validate(res.body, schema).should.be.true;
+        done();
+      });
+    });
+    it('should respond with 400 NOT OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "properties": {
+          "meta": "string",
+          "data": "number"
+        }
+      };
+      /*eslint-enable*/
+      api.get('/')
+      .set('Accept', 'application/json')
+      .expect(400)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        validator.validate(res.body, schema).should.be.true;
+        done();
+      });
+    });
+    it('should respond with 500 SERVER ERROR', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "properties": {
+          "meta": "string",
+          "data": "number",
+          "UserObj": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "integer"
+                },
+                "username": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+      api.get('/')
+      .set('Accept', 'application/xml')
+      .expect(500)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        validator.validate(res.body, schema).should.be.true;
+        done();
+      });
+    });
+    it('should respond with 500 SERVER ERROR', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "properties": {
+          "meta": "string",
+          "data": "number",
+          "UserObj": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "integer"
+                },
+                "username": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+      api.get('/')
+      .set('Accept', 'application/json')
+      .expect(500)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        validator.validate(res.body, schema).should.be.true;
+        done();
+      });
+    });
+  });
+
+  describe('post', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "integer"
+            },
+            "username": {
+              "type": "string"
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+      api.post('/?longitude=DATA')
+      .set('Accept', 'application/xml')
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        validator.validate(res.body, schema).should.be.true;
+        done();
+      });
+    });
+
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "integer"
+            },
+            "username": {
+              "type": "string"
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+      api.post('/?longitude=DATA')
+      .set('Accept', 'application/json')
+      .send({
+        latitude: 'DATA GOES HERE'
+      })
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        validator.validate(res.body, schema).should.be.true;
+        done();
+      });
+    });
+
+    it('should respond with 400 NOT OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "number"
+      };
+      /*eslint-enable*/
+      api.post('/?longitude=DATA')
+      .set('Accept', 'application/xml')
+      .expect(400)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        validator.validate(res.body, schema).should.be.true;
+        done();
+      });
+    });
+
+    it('should respond with 400 NOT OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "number"
+      };
+      /*eslint-enable*/
+      api.post('/?longitude=DATA')
+      .set('Accept', 'application/json')
+      .send({
+        latitude: 'DATA GOES HERE'
+      })
+      .expect(400)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        validator.validate(res.body, schema).should.be.true;
+        done();
+      });
+    });
+
+    it('should respond with 500 SERVER ERROR', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "string"
+      };
+      /*eslint-enable*/
+      api.post('/?longitude=DATA')
+      .set('Accept', 'application/xml')
+      .expect(500)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        validator.validate(res.body, schema).should.be.true;
+        done();
+      });
+    });
+
+    it('should respond with 500 SERVER ERROR', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "string"
+      };
+      /*eslint-enable*/
+      api.post('/?longitude=DATA')
+      .set('Accept', 'application/json')
+      .send({
+        latitude: 'DATA GOES HERE'
+      })
+      .expect(500)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        validator.validate(res.body, schema).should.be.true;
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/robust/compare/output10_user_Stub.js
+++ b/test/robust/compare/output10_user_Stub.js
@@ -12,9 +12,7 @@ describe('/user', function() {
       .set('Accept', 'application/xml')
       .expect(200)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         res.body.should.equal(null); // non-json response or no schema
         done();
@@ -25,9 +23,7 @@ describe('/user', function() {
       .set('Accept', 'application/json')
       .expect(200)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         res.body.should.equal(null); // non-json response or no schema
         done();
@@ -38,9 +34,7 @@ describe('/user', function() {
       .set('Accept', 'application/xml')
       .expect(400)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         res.body.should.equal(null); // non-json response or no schema
         done();
@@ -51,9 +45,7 @@ describe('/user', function() {
       .set('Accept', 'application/json')
       .expect(400)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         res.body.should.equal(null); // non-json response or no schema
         done();
@@ -64,9 +56,7 @@ describe('/user', function() {
       .set('Accept', 'application/xml')
       .expect(500)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         res.body.should.equal(null); // non-json response or no schema
         done();
@@ -77,9 +67,7 @@ describe('/user', function() {
       .set('Accept', 'application/json')
       .expect(500)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         res.body.should.equal(null); // non-json response or no schema
         done();
@@ -93,9 +81,7 @@ describe('/user', function() {
       .set('Accept', 'application/xml')
       .expect(200)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         res.body.should.equal(null); // non-json response or no schema
         done();
@@ -110,9 +96,7 @@ describe('/user', function() {
       })
       .expect(200)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         res.body.should.equal(null); // non-json response or no schema
         done();
@@ -124,9 +108,7 @@ describe('/user', function() {
       .set('Accept', 'application/xml')
       .expect(400)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         res.body.should.equal(null); // non-json response or no schema
         done();
@@ -141,9 +123,7 @@ describe('/user', function() {
       })
       .expect(400)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         res.body.should.equal(null); // non-json response or no schema
         done();
@@ -155,9 +135,7 @@ describe('/user', function() {
       .set('Accept', 'application/xml')
       .expect(500)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         res.body.should.equal(null); // non-json response or no schema
         done();
@@ -172,9 +150,7 @@ describe('/user', function() {
       })
       .expect(500)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         res.body.should.equal(null); // non-json response or no schema
         done();

--- a/test/robust/compare/output10_user_Stub.js
+++ b/test/robust/compare/output10_user_Stub.js
@@ -1,0 +1,186 @@
+'use strict';
+var chai = require('chai');
+
+chai.should();
+var supertest = require('supertest');
+var api = supertest('https://api.uber.com'); // supertest init;
+
+describe('/user', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      api.get('/user')
+      .set('Accept', 'application/xml')
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        res.body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+    it('should respond with 200 OK', function(done) {
+      api.get('/user')
+      .set('Accept', 'application/json')
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        res.body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+    it('should respond with 400 NOT OK', function(done) {
+      api.get('/user')
+      .set('Accept', 'application/xml')
+      .expect(400)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        res.body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+    it('should respond with 400 NOT OK', function(done) {
+      api.get('/user')
+      .set('Accept', 'application/json')
+      .expect(400)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        res.body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+    it('should respond with 500 SERVER ERROR', function(done) {
+      api.get('/user')
+      .set('Accept', 'application/xml')
+      .expect(500)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        res.body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+    it('should respond with 500 SERVER ERROR', function(done) {
+      api.get('/user')
+      .set('Accept', 'application/json')
+      .expect(500)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        res.body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+  });
+
+  describe('post', function() {
+    it('should respond with 200 OK', function(done) {
+      api.post('/user?longitude=DATA')
+      .set('Accept', 'application/xml')
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        res.body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 200 OK', function(done) {
+      api.post('/user?longitude=DATA')
+      .set('Accept', 'application/json')
+      .send({
+        latitude: 'DATA GOES HERE'
+      })
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        res.body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 400 NOT OK', function(done) {
+      api.post('/user?longitude=DATA')
+      .set('Accept', 'application/xml')
+      .expect(400)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        res.body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 400 NOT OK', function(done) {
+      api.post('/user?longitude=DATA')
+      .set('Accept', 'application/json')
+      .send({
+        latitude: 'DATA GOES HERE'
+      })
+      .expect(400)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        res.body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 500 SERVER ERROR', function(done) {
+      api.post('/user?longitude=DATA')
+      .set('Accept', 'application/xml')
+      .expect(500)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        res.body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 500 SERVER ERROR', function(done) {
+      api.post('/user?longitude=DATA')
+      .set('Accept', 'application/json')
+      .send({
+        latitude: 'DATA GOES HERE'
+      })
+      .expect(500)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        res.body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/robust/compare/output11__Stub.js
+++ b/test/robust/compare/output11__Stub.js
@@ -1,0 +1,186 @@
+'use strict';
+var chai = require('chai');
+
+chai.should();
+var supertest = require('supertest');
+var api = supertest('https://api.uber.com'); // supertest init;
+
+describe('/', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      api.get('/')
+      .set('Accept', 'application/xml')
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        res.body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+    it('should respond with 200 OK', function(done) {
+      api.get('/')
+      .set('Accept', 'application/json')
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        res.body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+    it('should respond with 400 NOT OK', function(done) {
+      api.get('/')
+      .set('Accept', 'application/xml')
+      .expect(400)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        res.body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+    it('should respond with 400 NOT OK', function(done) {
+      api.get('/')
+      .set('Accept', 'application/json')
+      .expect(400)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        res.body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+    it('should respond with 500 SERVER ERROR', function(done) {
+      api.get('/')
+      .set('Accept', 'application/xml')
+      .expect(500)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        res.body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+    it('should respond with 500 SERVER ERROR', function(done) {
+      api.get('/')
+      .set('Accept', 'application/json')
+      .expect(500)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        res.body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+  });
+
+  describe('post', function() {
+    it('should respond with 200 OK', function(done) {
+      api.post('/?longitude=DATA')
+      .set('Accept', 'application/xml')
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        res.body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 200 OK', function(done) {
+      api.post('/?longitude=DATA')
+      .set('Accept', 'application/json')
+      .send({
+        latitude: 'DATA GOES HERE'
+      })
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        res.body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 400 NOT OK', function(done) {
+      api.post('/?longitude=DATA')
+      .set('Accept', 'application/xml')
+      .expect(400)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        res.body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 400 NOT OK', function(done) {
+      api.post('/?longitude=DATA')
+      .set('Accept', 'application/json')
+      .send({
+        latitude: 'DATA GOES HERE'
+      })
+      .expect(400)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        res.body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 500 SERVER ERROR', function(done) {
+      api.post('/?longitude=DATA')
+      .set('Accept', 'application/xml')
+      .expect(500)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        res.body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 500 SERVER ERROR', function(done) {
+      api.post('/?longitude=DATA')
+      .set('Accept', 'application/json')
+      .send({
+        latitude: 'DATA GOES HERE'
+      })
+      .expect(500)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        res.body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/robust/compare/output11__Stub.js
+++ b/test/robust/compare/output11__Stub.js
@@ -12,9 +12,7 @@ describe('/', function() {
       .set('Accept', 'application/xml')
       .expect(200)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         res.body.should.equal(null); // non-json response or no schema
         done();
@@ -25,9 +23,7 @@ describe('/', function() {
       .set('Accept', 'application/json')
       .expect(200)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         res.body.should.equal(null); // non-json response or no schema
         done();
@@ -38,9 +34,7 @@ describe('/', function() {
       .set('Accept', 'application/xml')
       .expect(400)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         res.body.should.equal(null); // non-json response or no schema
         done();
@@ -51,9 +45,7 @@ describe('/', function() {
       .set('Accept', 'application/json')
       .expect(400)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         res.body.should.equal(null); // non-json response or no schema
         done();
@@ -64,9 +56,7 @@ describe('/', function() {
       .set('Accept', 'application/xml')
       .expect(500)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         res.body.should.equal(null); // non-json response or no schema
         done();
@@ -77,9 +67,7 @@ describe('/', function() {
       .set('Accept', 'application/json')
       .expect(500)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         res.body.should.equal(null); // non-json response or no schema
         done();
@@ -93,9 +81,7 @@ describe('/', function() {
       .set('Accept', 'application/xml')
       .expect(200)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         res.body.should.equal(null); // non-json response or no schema
         done();
@@ -110,9 +96,7 @@ describe('/', function() {
       })
       .expect(200)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         res.body.should.equal(null); // non-json response or no schema
         done();
@@ -124,9 +108,7 @@ describe('/', function() {
       .set('Accept', 'application/xml')
       .expect(400)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         res.body.should.equal(null); // non-json response or no schema
         done();
@@ -141,9 +123,7 @@ describe('/', function() {
       })
       .expect(400)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         res.body.should.equal(null); // non-json response or no schema
         done();
@@ -155,9 +135,7 @@ describe('/', function() {
       .set('Accept', 'application/xml')
       .expect(500)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         res.body.should.equal(null); // non-json response or no schema
         done();
@@ -172,9 +150,7 @@ describe('/', function() {
       })
       .expect(500)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         res.body.should.equal(null); // non-json response or no schema
         done();

--- a/test/robust/compare/output11_user_Stub.js
+++ b/test/robust/compare/output11_user_Stub.js
@@ -12,9 +12,7 @@ describe('/user', function() {
       .set('Accept', 'application/xml')
       .expect(200)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         res.body.should.equal(null); // non-json response or no schema
         done();
@@ -25,9 +23,7 @@ describe('/user', function() {
       .set('Accept', 'application/json')
       .expect(200)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         res.body.should.equal(null); // non-json response or no schema
         done();
@@ -38,9 +34,7 @@ describe('/user', function() {
       .set('Accept', 'application/xml')
       .expect(400)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         res.body.should.equal(null); // non-json response or no schema
         done();
@@ -51,9 +45,7 @@ describe('/user', function() {
       .set('Accept', 'application/json')
       .expect(400)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         res.body.should.equal(null); // non-json response or no schema
         done();
@@ -64,9 +56,7 @@ describe('/user', function() {
       .set('Accept', 'application/xml')
       .expect(500)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         res.body.should.equal(null); // non-json response or no schema
         done();
@@ -77,9 +67,7 @@ describe('/user', function() {
       .set('Accept', 'application/json')
       .expect(500)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         res.body.should.equal(null); // non-json response or no schema
         done();
@@ -93,9 +81,7 @@ describe('/user', function() {
       .set('Accept', 'application/xml')
       .expect(200)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         res.body.should.equal(null); // non-json response or no schema
         done();
@@ -110,9 +96,7 @@ describe('/user', function() {
       })
       .expect(200)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         res.body.should.equal(null); // non-json response or no schema
         done();
@@ -124,9 +108,7 @@ describe('/user', function() {
       .set('Accept', 'application/xml')
       .expect(400)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         res.body.should.equal(null); // non-json response or no schema
         done();
@@ -141,9 +123,7 @@ describe('/user', function() {
       })
       .expect(400)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         res.body.should.equal(null); // non-json response or no schema
         done();
@@ -155,9 +135,7 @@ describe('/user', function() {
       .set('Accept', 'application/xml')
       .expect(500)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         res.body.should.equal(null); // non-json response or no schema
         done();
@@ -172,9 +150,7 @@ describe('/user', function() {
       })
       .expect(500)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         res.body.should.equal(null); // non-json response or no schema
         done();

--- a/test/robust/compare/output11_user_Stub.js
+++ b/test/robust/compare/output11_user_Stub.js
@@ -1,0 +1,186 @@
+'use strict';
+var chai = require('chai');
+
+chai.should();
+var supertest = require('supertest');
+var api = supertest('https://api.uber.com'); // supertest init;
+
+describe('/user', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      api.get('/user')
+      .set('Accept', 'application/xml')
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        res.body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+    it('should respond with 200 OK', function(done) {
+      api.get('/user')
+      .set('Accept', 'application/json')
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        res.body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+    it('should respond with 400 NOT OK', function(done) {
+      api.get('/user')
+      .set('Accept', 'application/xml')
+      .expect(400)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        res.body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+    it('should respond with 400 NOT OK', function(done) {
+      api.get('/user')
+      .set('Accept', 'application/json')
+      .expect(400)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        res.body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+    it('should respond with 500 SERVER ERROR', function(done) {
+      api.get('/user')
+      .set('Accept', 'application/xml')
+      .expect(500)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        res.body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+    it('should respond with 500 SERVER ERROR', function(done) {
+      api.get('/user')
+      .set('Accept', 'application/json')
+      .expect(500)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        res.body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+  });
+
+  describe('post', function() {
+    it('should respond with 200 OK', function(done) {
+      api.post('/user?longitude=DATA')
+      .set('Accept', 'application/xml')
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        res.body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 200 OK', function(done) {
+      api.post('/user?longitude=DATA')
+      .set('Accept', 'application/json')
+      .send({
+        latitude: 'DATA GOES HERE'
+      })
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        res.body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 400 NOT OK', function(done) {
+      api.post('/user?longitude=DATA')
+      .set('Accept', 'application/xml')
+      .expect(400)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        res.body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 400 NOT OK', function(done) {
+      api.post('/user?longitude=DATA')
+      .set('Accept', 'application/json')
+      .send({
+        latitude: 'DATA GOES HERE'
+      })
+      .expect(400)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        res.body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 500 SERVER ERROR', function(done) {
+      api.post('/user?longitude=DATA')
+      .set('Accept', 'application/xml')
+      .expect(500)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        res.body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 500 SERVER ERROR', function(done) {
+      api.post('/user?longitude=DATA')
+      .set('Accept', 'application/json')
+      .send({
+        latitude: 'DATA GOES HERE'
+      })
+      .expect(500)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        res.body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/robust/compare/output12__Stub.js
+++ b/test/robust/compare/output12__Stub.js
@@ -14,9 +14,7 @@ describe('/', function() {
       .set('Accept', 'application/xml')
       .expect(200)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         res.body.should.equal(null); // non-json response or no schema
         done();
@@ -40,9 +38,7 @@ describe('/', function() {
       .set('Accept', 'application/xml')
       .expect(200)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         validator.validate(res.body, schema).should.be.true;
         done();
@@ -53,9 +49,7 @@ describe('/', function() {
       .set('Accept', 'application/json')
       .expect(200)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         res.body.should.equal(null); // non-json response or no schema
         done();
@@ -79,9 +73,7 @@ describe('/', function() {
       .set('Accept', 'application/json')
       .expect(200)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         validator.validate(res.body, schema).should.be.true;
         done();
@@ -92,9 +84,7 @@ describe('/', function() {
       .set('Accept', 'application/xml')
       .expect(400)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         res.body.should.equal(null); // non-json response or no schema
         done();
@@ -114,9 +104,7 @@ describe('/', function() {
       .set('Accept', 'application/xml')
       .expect(400)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         validator.validate(res.body, schema).should.be.true;
         done();
@@ -127,9 +115,7 @@ describe('/', function() {
       .set('Accept', 'application/json')
       .expect(400)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         res.body.should.equal(null); // non-json response or no schema
         done();
@@ -149,9 +135,7 @@ describe('/', function() {
       .set('Accept', 'application/json')
       .expect(400)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         validator.validate(res.body, schema).should.be.true;
         done();
@@ -162,9 +146,7 @@ describe('/', function() {
       .set('Accept', 'application/xml')
       .expect(500)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         res.body.should.equal(null); // non-json response or no schema
         done();
@@ -196,9 +178,7 @@ describe('/', function() {
       .set('Accept', 'application/xml')
       .expect(500)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         validator.validate(res.body, schema).should.be.true;
         done();
@@ -209,9 +189,7 @@ describe('/', function() {
       .set('Accept', 'application/json')
       .expect(500)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         res.body.should.equal(null); // non-json response or no schema
         done();
@@ -243,9 +221,7 @@ describe('/', function() {
       .set('Accept', 'application/json')
       .expect(500)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         validator.validate(res.body, schema).should.be.true;
         done();
@@ -259,9 +235,7 @@ describe('/', function() {
       .set('Accept', 'application/xml')
       .expect(200)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         res.body.should.equal(null); // non-json response or no schema
         done();
@@ -289,9 +263,7 @@ describe('/', function() {
       .set('Accept', 'application/xml')
       .expect(200)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         validator.validate(res.body, schema).should.be.true;
         done();
@@ -306,9 +278,7 @@ describe('/', function() {
       })
       .expect(200)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         res.body.should.equal(null); // non-json response or no schema
         done();
@@ -339,9 +309,7 @@ describe('/', function() {
       })
       .expect(200)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         validator.validate(res.body, schema).should.be.true;
         done();
@@ -353,9 +321,7 @@ describe('/', function() {
       .set('Accept', 'application/xml')
       .expect(400)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         res.body.should.equal(null); // non-json response or no schema
         done();
@@ -372,9 +338,7 @@ describe('/', function() {
       .set('Accept', 'application/xml')
       .expect(400)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         validator.validate(res.body, schema).should.be.true;
         done();
@@ -389,9 +353,7 @@ describe('/', function() {
       })
       .expect(400)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         res.body.should.equal(null); // non-json response or no schema
         done();
@@ -411,9 +373,7 @@ describe('/', function() {
       })
       .expect(400)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         validator.validate(res.body, schema).should.be.true;
         done();
@@ -425,9 +385,7 @@ describe('/', function() {
       .set('Accept', 'application/xml')
       .expect(500)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         res.body.should.equal(null); // non-json response or no schema
         done();
@@ -444,9 +402,7 @@ describe('/', function() {
       .set('Accept', 'application/xml')
       .expect(500)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         validator.validate(res.body, schema).should.be.true;
         done();
@@ -461,9 +417,7 @@ describe('/', function() {
       })
       .expect(500)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         res.body.should.equal(null); // non-json response or no schema
         done();
@@ -483,9 +437,7 @@ describe('/', function() {
       })
       .expect(500)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         validator.validate(res.body, schema).should.be.true;
         done();

--- a/test/robust/compare/output12__Stub.js
+++ b/test/robust/compare/output12__Stub.js
@@ -1,0 +1,497 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+
+chai.should();
+var supertest = require('supertest');
+var api = supertest('https://api.uber.com'); // supertest init;
+
+describe('/', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      api.get('/')
+      .set('Accept', 'application/xml')
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        res.body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "username": {
+            "type": "string"
+          }
+        }
+      };
+      /*eslint-enable*/
+      api.get('/')
+      .set('Accept', 'application/xml')
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        validator.validate(res.body, schema).should.be.true;
+        done();
+      });
+    });
+    it('should respond with 200 OK', function(done) {
+      api.get('/')
+      .set('Accept', 'application/json')
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        res.body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "username": {
+            "type": "string"
+          }
+        }
+      };
+      /*eslint-enable*/
+      api.get('/')
+      .set('Accept', 'application/json')
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        validator.validate(res.body, schema).should.be.true;
+        done();
+      });
+    });
+    it('should respond with 400 NOT OK', function(done) {
+      api.get('/')
+      .set('Accept', 'application/xml')
+      .expect(400)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        res.body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+    it('should respond with 400 NOT OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "properties": {
+          "meta": "string",
+          "data": "number"
+        }
+      };
+      /*eslint-enable*/
+      api.get('/')
+      .set('Accept', 'application/xml')
+      .expect(400)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        validator.validate(res.body, schema).should.be.true;
+        done();
+      });
+    });
+    it('should respond with 400 NOT OK', function(done) {
+      api.get('/')
+      .set('Accept', 'application/json')
+      .expect(400)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        res.body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+    it('should respond with 400 NOT OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "properties": {
+          "meta": "string",
+          "data": "number"
+        }
+      };
+      /*eslint-enable*/
+      api.get('/')
+      .set('Accept', 'application/json')
+      .expect(400)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        validator.validate(res.body, schema).should.be.true;
+        done();
+      });
+    });
+    it('should respond with 500 SERVER ERROR', function(done) {
+      api.get('/')
+      .set('Accept', 'application/xml')
+      .expect(500)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        res.body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+    it('should respond with 500 SERVER ERROR', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "properties": {
+          "meta": "string",
+          "data": "number",
+          "UserObj": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "integer"
+                },
+                "username": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+      api.get('/')
+      .set('Accept', 'application/xml')
+      .expect(500)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        validator.validate(res.body, schema).should.be.true;
+        done();
+      });
+    });
+    it('should respond with 500 SERVER ERROR', function(done) {
+      api.get('/')
+      .set('Accept', 'application/json')
+      .expect(500)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        res.body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+    it('should respond with 500 SERVER ERROR', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "properties": {
+          "meta": "string",
+          "data": "number",
+          "UserObj": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "integer"
+                },
+                "username": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+      api.get('/')
+      .set('Accept', 'application/json')
+      .expect(500)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        validator.validate(res.body, schema).should.be.true;
+        done();
+      });
+    });
+  });
+
+  describe('post', function() {
+    it('should respond with 200 OK', function(done) {
+      api.post('/?longitude=DATA')
+      .set('Accept', 'application/xml')
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        res.body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "integer"
+            },
+            "username": {
+              "type": "string"
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+      api.post('/?longitude=DATA')
+      .set('Accept', 'application/xml')
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        validator.validate(res.body, schema).should.be.true;
+        done();
+      });
+    });
+
+    it('should respond with 200 OK', function(done) {
+      api.post('/?longitude=DATA')
+      .set('Accept', 'application/json')
+      .send({
+        latitude: 'DATA GOES HERE'
+      })
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        res.body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "integer"
+            },
+            "username": {
+              "type": "string"
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+      api.post('/?longitude=DATA')
+      .set('Accept', 'application/json')
+      .send({
+        latitude: 'DATA GOES HERE'
+      })
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        validator.validate(res.body, schema).should.be.true;
+        done();
+      });
+    });
+
+    it('should respond with 400 NOT OK', function(done) {
+      api.post('/?longitude=DATA')
+      .set('Accept', 'application/xml')
+      .expect(400)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        res.body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 400 NOT OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "number"
+      };
+      /*eslint-enable*/
+      api.post('/?longitude=DATA')
+      .set('Accept', 'application/xml')
+      .expect(400)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        validator.validate(res.body, schema).should.be.true;
+        done();
+      });
+    });
+
+    it('should respond with 400 NOT OK', function(done) {
+      api.post('/?longitude=DATA')
+      .set('Accept', 'application/json')
+      .send({
+        latitude: 'DATA GOES HERE'
+      })
+      .expect(400)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        res.body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 400 NOT OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "number"
+      };
+      /*eslint-enable*/
+      api.post('/?longitude=DATA')
+      .set('Accept', 'application/json')
+      .send({
+        latitude: 'DATA GOES HERE'
+      })
+      .expect(400)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        validator.validate(res.body, schema).should.be.true;
+        done();
+      });
+    });
+
+    it('should respond with 500 SERVER ERROR', function(done) {
+      api.post('/?longitude=DATA')
+      .set('Accept', 'application/xml')
+      .expect(500)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        res.body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 500 SERVER ERROR', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "string"
+      };
+      /*eslint-enable*/
+      api.post('/?longitude=DATA')
+      .set('Accept', 'application/xml')
+      .expect(500)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        validator.validate(res.body, schema).should.be.true;
+        done();
+      });
+    });
+
+    it('should respond with 500 SERVER ERROR', function(done) {
+      api.post('/?longitude=DATA')
+      .set('Accept', 'application/json')
+      .send({
+        latitude: 'DATA GOES HERE'
+      })
+      .expect(500)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        res.body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 500 SERVER ERROR', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "string"
+      };
+      /*eslint-enable*/
+      api.post('/?longitude=DATA')
+      .set('Accept', 'application/json')
+      .send({
+        latitude: 'DATA GOES HERE'
+      })
+      .expect(500)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        validator.validate(res.body, schema).should.be.true;
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/robust/compare/output12_user_Stub.js
+++ b/test/robust/compare/output12_user_Stub.js
@@ -12,9 +12,7 @@ describe('/user', function() {
       .set('Accept', 'application/xml')
       .expect(200)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         res.body.should.equal(null); // non-json response or no schema
         done();
@@ -25,9 +23,7 @@ describe('/user', function() {
       .set('Accept', 'application/xml')
       .expect(200)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         res.body.should.equal(null); // non-json response or no schema
         done();
@@ -38,9 +34,7 @@ describe('/user', function() {
       .set('Accept', 'application/json')
       .expect(200)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         res.body.should.equal(null); // non-json response or no schema
         done();
@@ -51,9 +45,7 @@ describe('/user', function() {
       .set('Accept', 'application/json')
       .expect(200)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         res.body.should.equal(null); // non-json response or no schema
         done();
@@ -64,9 +56,7 @@ describe('/user', function() {
       .set('Accept', 'application/xml')
       .expect(400)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         res.body.should.equal(null); // non-json response or no schema
         done();
@@ -77,9 +67,7 @@ describe('/user', function() {
       .set('Accept', 'application/xml')
       .expect(400)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         res.body.should.equal(null); // non-json response or no schema
         done();
@@ -90,9 +78,7 @@ describe('/user', function() {
       .set('Accept', 'application/json')
       .expect(400)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         res.body.should.equal(null); // non-json response or no schema
         done();
@@ -103,9 +89,7 @@ describe('/user', function() {
       .set('Accept', 'application/json')
       .expect(400)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         res.body.should.equal(null); // non-json response or no schema
         done();
@@ -116,9 +100,7 @@ describe('/user', function() {
       .set('Accept', 'application/xml')
       .expect(500)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         res.body.should.equal(null); // non-json response or no schema
         done();
@@ -129,9 +111,7 @@ describe('/user', function() {
       .set('Accept', 'application/xml')
       .expect(500)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         res.body.should.equal(null); // non-json response or no schema
         done();
@@ -142,9 +122,7 @@ describe('/user', function() {
       .set('Accept', 'application/json')
       .expect(500)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         res.body.should.equal(null); // non-json response or no schema
         done();
@@ -155,9 +133,7 @@ describe('/user', function() {
       .set('Accept', 'application/json')
       .expect(500)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         res.body.should.equal(null); // non-json response or no schema
         done();
@@ -171,9 +147,7 @@ describe('/user', function() {
       .set('Accept', 'application/xml')
       .expect(200)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         res.body.should.equal(null); // non-json response or no schema
         done();
@@ -185,9 +159,7 @@ describe('/user', function() {
       .set('Accept', 'application/xml')
       .expect(200)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         res.body.should.equal(null); // non-json response or no schema
         done();
@@ -202,9 +174,7 @@ describe('/user', function() {
       })
       .expect(200)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         res.body.should.equal(null); // non-json response or no schema
         done();
@@ -219,9 +189,7 @@ describe('/user', function() {
       })
       .expect(200)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         res.body.should.equal(null); // non-json response or no schema
         done();
@@ -233,9 +201,7 @@ describe('/user', function() {
       .set('Accept', 'application/xml')
       .expect(400)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         res.body.should.equal(null); // non-json response or no schema
         done();
@@ -247,9 +213,7 @@ describe('/user', function() {
       .set('Accept', 'application/xml')
       .expect(400)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         res.body.should.equal(null); // non-json response or no schema
         done();
@@ -264,9 +228,7 @@ describe('/user', function() {
       })
       .expect(400)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         res.body.should.equal(null); // non-json response or no schema
         done();
@@ -281,9 +243,7 @@ describe('/user', function() {
       })
       .expect(400)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         res.body.should.equal(null); // non-json response or no schema
         done();
@@ -295,9 +255,7 @@ describe('/user', function() {
       .set('Accept', 'application/xml')
       .expect(500)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         res.body.should.equal(null); // non-json response or no schema
         done();
@@ -309,9 +267,7 @@ describe('/user', function() {
       .set('Accept', 'application/xml')
       .expect(500)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         res.body.should.equal(null); // non-json response or no schema
         done();
@@ -326,9 +282,7 @@ describe('/user', function() {
       })
       .expect(500)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         res.body.should.equal(null); // non-json response or no schema
         done();
@@ -343,9 +297,7 @@ describe('/user', function() {
       })
       .expect(500)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         res.body.should.equal(null); // non-json response or no schema
         done();

--- a/test/robust/compare/output12_user_Stub.js
+++ b/test/robust/compare/output12_user_Stub.js
@@ -1,0 +1,357 @@
+'use strict';
+var chai = require('chai');
+
+chai.should();
+var supertest = require('supertest');
+var api = supertest('https://api.uber.com'); // supertest init;
+
+describe('/user', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      api.get('/user')
+      .set('Accept', 'application/xml')
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        res.body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+    it('should respond with 200 OK', function(done) {
+      api.get('/user')
+      .set('Accept', 'application/xml')
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        res.body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+    it('should respond with 200 OK', function(done) {
+      api.get('/user')
+      .set('Accept', 'application/json')
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        res.body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+    it('should respond with 200 OK', function(done) {
+      api.get('/user')
+      .set('Accept', 'application/json')
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        res.body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+    it('should respond with 400 NOT OK', function(done) {
+      api.get('/user')
+      .set('Accept', 'application/xml')
+      .expect(400)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        res.body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+    it('should respond with 400 NOT OK', function(done) {
+      api.get('/user')
+      .set('Accept', 'application/xml')
+      .expect(400)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        res.body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+    it('should respond with 400 NOT OK', function(done) {
+      api.get('/user')
+      .set('Accept', 'application/json')
+      .expect(400)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        res.body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+    it('should respond with 400 NOT OK', function(done) {
+      api.get('/user')
+      .set('Accept', 'application/json')
+      .expect(400)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        res.body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+    it('should respond with 500 SERVER ERROR', function(done) {
+      api.get('/user')
+      .set('Accept', 'application/xml')
+      .expect(500)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        res.body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+    it('should respond with 500 SERVER ERROR', function(done) {
+      api.get('/user')
+      .set('Accept', 'application/xml')
+      .expect(500)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        res.body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+    it('should respond with 500 SERVER ERROR', function(done) {
+      api.get('/user')
+      .set('Accept', 'application/json')
+      .expect(500)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        res.body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+    it('should respond with 500 SERVER ERROR', function(done) {
+      api.get('/user')
+      .set('Accept', 'application/json')
+      .expect(500)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        res.body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+  });
+
+  describe('post', function() {
+    it('should respond with 200 OK', function(done) {
+      api.post('/user?longitude=DATA')
+      .set('Accept', 'application/xml')
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        res.body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 200 OK', function(done) {
+      api.post('/user?longitude=DATA')
+      .set('Accept', 'application/xml')
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        res.body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 200 OK', function(done) {
+      api.post('/user?longitude=DATA')
+      .set('Accept', 'application/json')
+      .send({
+        latitude: 'DATA GOES HERE'
+      })
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        res.body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 200 OK', function(done) {
+      api.post('/user?longitude=DATA')
+      .set('Accept', 'application/json')
+      .send({
+        latitude: 'DATA GOES HERE'
+      })
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        res.body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 400 NOT OK', function(done) {
+      api.post('/user?longitude=DATA')
+      .set('Accept', 'application/xml')
+      .expect(400)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        res.body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 400 NOT OK', function(done) {
+      api.post('/user?longitude=DATA')
+      .set('Accept', 'application/xml')
+      .expect(400)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        res.body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 400 NOT OK', function(done) {
+      api.post('/user?longitude=DATA')
+      .set('Accept', 'application/json')
+      .send({
+        latitude: 'DATA GOES HERE'
+      })
+      .expect(400)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        res.body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 400 NOT OK', function(done) {
+      api.post('/user?longitude=DATA')
+      .set('Accept', 'application/json')
+      .send({
+        latitude: 'DATA GOES HERE'
+      })
+      .expect(400)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        res.body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 500 SERVER ERROR', function(done) {
+      api.post('/user?longitude=DATA')
+      .set('Accept', 'application/xml')
+      .expect(500)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        res.body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 500 SERVER ERROR', function(done) {
+      api.post('/user?longitude=DATA')
+      .set('Accept', 'application/xml')
+      .expect(500)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        res.body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 500 SERVER ERROR', function(done) {
+      api.post('/user?longitude=DATA')
+      .set('Accept', 'application/json')
+      .send({
+        latitude: 'DATA GOES HERE'
+      })
+      .expect(500)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        res.body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 500 SERVER ERROR', function(done) {
+      api.post('/user?longitude=DATA')
+      .set('Accept', 'application/json')
+      .send({
+        latitude: 'DATA GOES HERE'
+      })
+      .expect(500)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        res.body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/robust/compare/output13__Stub.js
+++ b/test/robust/compare/output13__Stub.js
@@ -1,0 +1,266 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+
+chai.should();
+var supertest = require('supertest');
+var api = supertest('https://api.uber.com'); // supertest init;
+
+describe('/', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      api.get('/')
+      .set('Accept', 'application/json')
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        res.body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "username": {
+            "type": "string"
+          }
+        }
+      };
+      /*eslint-enable*/
+      api.get('/')
+      .set('Accept', 'application/json')
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        validator.validate(res.body, schema).should.be.true;
+        done();
+      });
+    });
+    it('should respond with 400 NOT OK', function(done) {
+      api.get('/')
+      .set('Accept', 'application/json')
+      .expect(400)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        res.body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+    it('should respond with 400 NOT OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "properties": {
+          "meta": "string",
+          "data": "number"
+        }
+      };
+      /*eslint-enable*/
+      api.get('/')
+      .set('Accept', 'application/json')
+      .expect(400)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        validator.validate(res.body, schema).should.be.true;
+        done();
+      });
+    });
+    it('should respond with 500 SERVER ERROR', function(done) {
+      api.get('/')
+      .set('Accept', 'application/json')
+      .expect(500)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        res.body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+    it('should respond with 500 SERVER ERROR', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "properties": {
+          "meta": "string",
+          "data": "number",
+          "UserObj": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "integer"
+                },
+                "username": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+      api.get('/')
+      .set('Accept', 'application/json')
+      .expect(500)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        validator.validate(res.body, schema).should.be.true;
+        done();
+      });
+    });
+  });
+
+  describe('post', function() {
+    it('should respond with 200 OK', function(done) {
+      api.post('/?longitude=DATA')
+      .set('Accept', 'application/json')
+      .send({
+        latitude: 'DATA GOES HERE'
+      })
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        res.body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "integer"
+            },
+            "username": {
+              "type": "string"
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+      api.post('/?longitude=DATA')
+      .set('Accept', 'application/json')
+      .send({
+        latitude: 'DATA GOES HERE'
+      })
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        validator.validate(res.body, schema).should.be.true;
+        done();
+      });
+    });
+
+    it('should respond with 400 NOT OK', function(done) {
+      api.post('/?longitude=DATA')
+      .set('Accept', 'application/json')
+      .send({
+        latitude: 'DATA GOES HERE'
+      })
+      .expect(400)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        res.body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 400 NOT OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "number"
+      };
+      /*eslint-enable*/
+      api.post('/?longitude=DATA')
+      .set('Accept', 'application/json')
+      .send({
+        latitude: 'DATA GOES HERE'
+      })
+      .expect(400)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        validator.validate(res.body, schema).should.be.true;
+        done();
+      });
+    });
+
+    it('should respond with 500 SERVER ERROR', function(done) {
+      api.post('/?longitude=DATA')
+      .set('Accept', 'application/json')
+      .send({
+        latitude: 'DATA GOES HERE'
+      })
+      .expect(500)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        res.body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 500 SERVER ERROR', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "string"
+      };
+      /*eslint-enable*/
+      api.post('/?longitude=DATA')
+      .set('Accept', 'application/json')
+      .send({
+        latitude: 'DATA GOES HERE'
+      })
+      .expect(500)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        validator.validate(res.body, schema).should.be.true;
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/robust/compare/output13__Stub.js
+++ b/test/robust/compare/output13__Stub.js
@@ -14,9 +14,7 @@ describe('/', function() {
       .set('Accept', 'application/json')
       .expect(200)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         res.body.should.equal(null); // non-json response or no schema
         done();
@@ -40,9 +38,7 @@ describe('/', function() {
       .set('Accept', 'application/json')
       .expect(200)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         validator.validate(res.body, schema).should.be.true;
         done();
@@ -53,9 +49,7 @@ describe('/', function() {
       .set('Accept', 'application/json')
       .expect(400)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         res.body.should.equal(null); // non-json response or no schema
         done();
@@ -75,9 +69,7 @@ describe('/', function() {
       .set('Accept', 'application/json')
       .expect(400)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         validator.validate(res.body, schema).should.be.true;
         done();
@@ -88,9 +80,7 @@ describe('/', function() {
       .set('Accept', 'application/json')
       .expect(500)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         res.body.should.equal(null); // non-json response or no schema
         done();
@@ -122,9 +112,7 @@ describe('/', function() {
       .set('Accept', 'application/json')
       .expect(500)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         validator.validate(res.body, schema).should.be.true;
         done();
@@ -141,9 +129,7 @@ describe('/', function() {
       })
       .expect(200)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         res.body.should.equal(null); // non-json response or no schema
         done();
@@ -174,9 +160,7 @@ describe('/', function() {
       })
       .expect(200)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         validator.validate(res.body, schema).should.be.true;
         done();
@@ -191,9 +175,7 @@ describe('/', function() {
       })
       .expect(400)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         res.body.should.equal(null); // non-json response or no schema
         done();
@@ -213,9 +195,7 @@ describe('/', function() {
       })
       .expect(400)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         validator.validate(res.body, schema).should.be.true;
         done();
@@ -230,9 +210,7 @@ describe('/', function() {
       })
       .expect(500)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         res.body.should.equal(null); // non-json response or no schema
         done();
@@ -252,9 +230,7 @@ describe('/', function() {
       })
       .expect(500)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         validator.validate(res.body, schema).should.be.true;
         done();

--- a/test/robust/compare/output13_user_Stub.js
+++ b/test/robust/compare/output13_user_Stub.js
@@ -1,0 +1,195 @@
+'use strict';
+var chai = require('chai');
+
+chai.should();
+var supertest = require('supertest');
+var api = supertest('https://api.uber.com'); // supertest init;
+
+describe('/user', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      api.get('/user')
+      .set('Accept', 'application/json')
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        res.body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+    it('should respond with 200 OK', function(done) {
+      api.get('/user')
+      .set('Accept', 'application/json')
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        res.body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+    it('should respond with 400 NOT OK', function(done) {
+      api.get('/user')
+      .set('Accept', 'application/json')
+      .expect(400)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        res.body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+    it('should respond with 400 NOT OK', function(done) {
+      api.get('/user')
+      .set('Accept', 'application/json')
+      .expect(400)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        res.body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+    it('should respond with 500 SERVER ERROR', function(done) {
+      api.get('/user')
+      .set('Accept', 'application/json')
+      .expect(500)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        res.body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+    it('should respond with 500 SERVER ERROR', function(done) {
+      api.get('/user')
+      .set('Accept', 'application/json')
+      .expect(500)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        res.body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+  });
+
+  describe('post', function() {
+    it('should respond with 200 OK', function(done) {
+      api.post('/user?longitude=DATA')
+      .set('Accept', 'application/json')
+      .send({
+        latitude: 'DATA GOES HERE'
+      })
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        res.body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 200 OK', function(done) {
+      api.post('/user?longitude=DATA')
+      .set('Accept', 'application/json')
+      .send({
+        latitude: 'DATA GOES HERE'
+      })
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        res.body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 400 NOT OK', function(done) {
+      api.post('/user?longitude=DATA')
+      .set('Accept', 'application/json')
+      .send({
+        latitude: 'DATA GOES HERE'
+      })
+      .expect(400)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        res.body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 400 NOT OK', function(done) {
+      api.post('/user?longitude=DATA')
+      .set('Accept', 'application/json')
+      .send({
+        latitude: 'DATA GOES HERE'
+      })
+      .expect(400)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        res.body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 500 SERVER ERROR', function(done) {
+      api.post('/user?longitude=DATA')
+      .set('Accept', 'application/json')
+      .send({
+        latitude: 'DATA GOES HERE'
+      })
+      .expect(500)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        res.body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 500 SERVER ERROR', function(done) {
+      api.post('/user?longitude=DATA')
+      .set('Accept', 'application/json')
+      .send({
+        latitude: 'DATA GOES HERE'
+      })
+      .expect(500)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        res.body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/robust/compare/output13_user_Stub.js
+++ b/test/robust/compare/output13_user_Stub.js
@@ -12,9 +12,7 @@ describe('/user', function() {
       .set('Accept', 'application/json')
       .expect(200)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         res.body.should.equal(null); // non-json response or no schema
         done();
@@ -25,9 +23,7 @@ describe('/user', function() {
       .set('Accept', 'application/json')
       .expect(200)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         res.body.should.equal(null); // non-json response or no schema
         done();
@@ -38,9 +34,7 @@ describe('/user', function() {
       .set('Accept', 'application/json')
       .expect(400)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         res.body.should.equal(null); // non-json response or no schema
         done();
@@ -51,9 +45,7 @@ describe('/user', function() {
       .set('Accept', 'application/json')
       .expect(400)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         res.body.should.equal(null); // non-json response or no schema
         done();
@@ -64,9 +56,7 @@ describe('/user', function() {
       .set('Accept', 'application/json')
       .expect(500)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         res.body.should.equal(null); // non-json response or no schema
         done();
@@ -77,9 +67,7 @@ describe('/user', function() {
       .set('Accept', 'application/json')
       .expect(500)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         res.body.should.equal(null); // non-json response or no schema
         done();
@@ -96,9 +84,7 @@ describe('/user', function() {
       })
       .expect(200)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         res.body.should.equal(null); // non-json response or no schema
         done();
@@ -113,9 +99,7 @@ describe('/user', function() {
       })
       .expect(200)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         res.body.should.equal(null); // non-json response or no schema
         done();
@@ -130,9 +114,7 @@ describe('/user', function() {
       })
       .expect(400)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         res.body.should.equal(null); // non-json response or no schema
         done();
@@ -147,9 +129,7 @@ describe('/user', function() {
       })
       .expect(400)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         res.body.should.equal(null); // non-json response or no schema
         done();
@@ -164,9 +144,7 @@ describe('/user', function() {
       })
       .expect(500)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         res.body.should.equal(null); // non-json response or no schema
         done();
@@ -181,9 +159,7 @@ describe('/user', function() {
       })
       .expect(500)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         res.body.should.equal(null); // non-json response or no schema
         done();

--- a/test/robust/compare/output14__Stub.js
+++ b/test/robust/compare/output14__Stub.js
@@ -17,9 +17,8 @@ describe('/', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(200);
 
         body.should.equal(null); // non-json response or no schema
@@ -49,9 +48,8 @@ describe('/', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(200);
 
         validator.validate(body, schema).should.be.true;
@@ -68,9 +66,8 @@ describe('/', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(400);
 
         body.should.equal(null); // non-json response or no schema
@@ -96,9 +93,8 @@ describe('/', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(400);
 
         validator.validate(body, schema).should.be.true;
@@ -115,9 +111,8 @@ describe('/', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(500);
 
         body.should.equal(null); // non-json response or no schema
@@ -155,9 +150,8 @@ describe('/', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(500);
 
         validator.validate(body, schema).should.be.true;
@@ -183,9 +177,8 @@ describe('/', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(200);
 
         body.should.equal(null); // non-json response or no schema
@@ -224,9 +217,8 @@ describe('/', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(200);
 
         validator.validate(body, schema).should.be.true;
@@ -249,9 +241,8 @@ describe('/', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(400);
 
         body.should.equal(null); // non-json response or no schema
@@ -279,9 +270,8 @@ describe('/', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(400);
 
         validator.validate(body, schema).should.be.true;
@@ -304,9 +294,8 @@ describe('/', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(500);
 
         body.should.equal(null); // non-json response or no schema
@@ -334,9 +323,8 @@ describe('/', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(500);
 
         validator.validate(body, schema).should.be.true;

--- a/test/robust/compare/output14__Stub.js
+++ b/test/robust/compare/output14__Stub.js
@@ -1,0 +1,349 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+
+chai.should();
+var request = require('request');
+
+describe('/', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      request({
+        url: 'https://api.uber.com/',
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(200);
+
+        body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "username": {
+            "type": "string"
+          }
+        }
+      };
+      /*eslint-enable*/
+      request({
+        url: 'https://api.uber.com/',
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(200);
+
+        validator.validate(body, schema).should.be.true;
+        done();
+      });
+    });
+
+    it('should respond with 400 NOT OK', function(done) {
+      request({
+        url: 'https://api.uber.com/',
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(400);
+
+        body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 400 NOT OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "properties": {
+          "meta": "string",
+          "data": "number"
+        }
+      };
+      /*eslint-enable*/
+      request({
+        url: 'https://api.uber.com/',
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(400);
+
+        validator.validate(body, schema).should.be.true;
+        done();
+      });
+    });
+
+    it('should respond with 500 SERVER ERROR', function(done) {
+      request({
+        url: 'https://api.uber.com/',
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(500);
+
+        body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 500 SERVER ERROR', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "properties": {
+          "meta": "string",
+          "data": "number",
+          "UserObj": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "integer"
+                },
+                "username": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+      request({
+        url: 'https://api.uber.com/',
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(500);
+
+        validator.validate(body, schema).should.be.true;
+        done();
+      });
+    });
+
+  });
+
+  describe('post', function() {
+    it('should respond with 200 OK', function(done) {
+      request({
+        url: 'https://api.uber.com/',
+        qs: {
+          longitude: 'DATA GOES HERE'
+        },
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        json: {
+          latitude: 'DATA GOES HERE'
+        }
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(200);
+
+        body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "integer"
+            },
+            "username": {
+              "type": "string"
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+      request({
+        url: 'https://api.uber.com/',
+        qs: {
+          longitude: 'DATA GOES HERE'
+        },
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        json: {
+          latitude: 'DATA GOES HERE'
+        }
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(200);
+
+        validator.validate(body, schema).should.be.true;
+        done();
+      });
+    });
+
+    it('should respond with 400 NOT OK', function(done) {
+      request({
+        url: 'https://api.uber.com/',
+        qs: {
+          longitude: 'DATA GOES HERE'
+        },
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        json: {
+          latitude: 'DATA GOES HERE'
+        }
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(400);
+
+        body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 400 NOT OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "number"
+      };
+      /*eslint-enable*/
+      request({
+        url: 'https://api.uber.com/',
+        qs: {
+          longitude: 'DATA GOES HERE'
+        },
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        json: {
+          latitude: 'DATA GOES HERE'
+        }
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(400);
+
+        validator.validate(body, schema).should.be.true;
+        done();
+      });
+    });
+
+    it('should respond with 500 SERVER ERROR', function(done) {
+      request({
+        url: 'https://api.uber.com/',
+        qs: {
+          longitude: 'DATA GOES HERE'
+        },
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        json: {
+          latitude: 'DATA GOES HERE'
+        }
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(500);
+
+        body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 500 SERVER ERROR', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "string"
+      };
+      /*eslint-enable*/
+      request({
+        url: 'https://api.uber.com/',
+        qs: {
+          longitude: 'DATA GOES HERE'
+        },
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        json: {
+          latitude: 'DATA GOES HERE'
+        }
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(500);
+
+        validator.validate(body, schema).should.be.true;
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/robust/compare/output14_user_Stub.js
+++ b/test/robust/compare/output14_user_Stub.js
@@ -15,9 +15,8 @@ describe('/user', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(200);
 
         body.should.equal(null); // non-json response or no schema
@@ -34,9 +33,8 @@ describe('/user', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(200);
 
         body.should.equal(null); // non-json response or no schema
@@ -53,9 +51,8 @@ describe('/user', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(400);
 
         body.should.equal(null); // non-json response or no schema
@@ -72,9 +69,8 @@ describe('/user', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(400);
 
         body.should.equal(null); // non-json response or no schema
@@ -91,9 +87,8 @@ describe('/user', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(500);
 
         body.should.equal(null); // non-json response or no schema
@@ -110,9 +105,8 @@ describe('/user', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(500);
 
         body.should.equal(null); // non-json response or no schema
@@ -138,9 +132,8 @@ describe('/user', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(200);
 
         body.should.equal(null); // non-json response or no schema
@@ -163,9 +156,8 @@ describe('/user', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(200);
 
         body.should.equal(null); // non-json response or no schema
@@ -188,9 +180,8 @@ describe('/user', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(400);
 
         body.should.equal(null); // non-json response or no schema
@@ -213,9 +204,8 @@ describe('/user', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(400);
 
         body.should.equal(null); // non-json response or no schema
@@ -238,9 +228,8 @@ describe('/user', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(500);
 
         body.should.equal(null); // non-json response or no schema
@@ -263,9 +252,8 @@ describe('/user', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(500);
 
         body.should.equal(null); // non-json response or no schema

--- a/test/robust/compare/output14_user_Stub.js
+++ b/test/robust/compare/output14_user_Stub.js
@@ -1,0 +1,278 @@
+'use strict';
+var chai = require('chai');
+
+chai.should();
+var request = require('request');
+
+describe('/user', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      request({
+        url: 'https://api.uber.com/user',
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(200);
+
+        body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 200 OK', function(done) {
+      request({
+        url: 'https://api.uber.com/user',
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(200);
+
+        body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 400 NOT OK', function(done) {
+      request({
+        url: 'https://api.uber.com/user',
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(400);
+
+        body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 400 NOT OK', function(done) {
+      request({
+        url: 'https://api.uber.com/user',
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(400);
+
+        body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 500 SERVER ERROR', function(done) {
+      request({
+        url: 'https://api.uber.com/user',
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(500);
+
+        body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 500 SERVER ERROR', function(done) {
+      request({
+        url: 'https://api.uber.com/user',
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(500);
+
+        body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+  });
+
+  describe('post', function() {
+    it('should respond with 200 OK', function(done) {
+      request({
+        url: 'https://api.uber.com/user',
+        qs: {
+          longitude: 'DATA GOES HERE'
+        },
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        json: {
+          latitude: 'DATA GOES HERE'
+        }
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(200);
+
+        body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 200 OK', function(done) {
+      request({
+        url: 'https://api.uber.com/user',
+        qs: {
+          longitude: 'DATA GOES HERE'
+        },
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        json: {
+          latitude: 'DATA GOES HERE'
+        }
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(200);
+
+        body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 400 NOT OK', function(done) {
+      request({
+        url: 'https://api.uber.com/user',
+        qs: {
+          longitude: 'DATA GOES HERE'
+        },
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        json: {
+          latitude: 'DATA GOES HERE'
+        }
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(400);
+
+        body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 400 NOT OK', function(done) {
+      request({
+        url: 'https://api.uber.com/user',
+        qs: {
+          longitude: 'DATA GOES HERE'
+        },
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        json: {
+          latitude: 'DATA GOES HERE'
+        }
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(400);
+
+        body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 500 SERVER ERROR', function(done) {
+      request({
+        url: 'https://api.uber.com/user',
+        qs: {
+          longitude: 'DATA GOES HERE'
+        },
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        json: {
+          latitude: 'DATA GOES HERE'
+        }
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(500);
+
+        body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 500 SERVER ERROR', function(done) {
+      request({
+        url: 'https://api.uber.com/user',
+        qs: {
+          longitude: 'DATA GOES HERE'
+        },
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        json: {
+          latitude: 'DATA GOES HERE'
+        }
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(500);
+
+        body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/robust/compare/output15__Stub.js
+++ b/test/robust/compare/output15__Stub.js
@@ -17,9 +17,8 @@ describe('/', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(200);
 
         body.should.equal(null); // non-json response or no schema
@@ -49,9 +48,8 @@ describe('/', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(200);
 
         validator.validate(body, schema).should.be.true;
@@ -68,9 +66,8 @@ describe('/', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(200);
 
         body.should.equal(null); // non-json response or no schema
@@ -100,9 +97,8 @@ describe('/', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(200);
 
         validator.validate(body, schema).should.be.true;
@@ -119,9 +115,8 @@ describe('/', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(400);
 
         body.should.equal(null); // non-json response or no schema
@@ -147,9 +142,8 @@ describe('/', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(400);
 
         validator.validate(body, schema).should.be.true;
@@ -166,9 +160,8 @@ describe('/', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(400);
 
         body.should.equal(null); // non-json response or no schema
@@ -194,9 +187,8 @@ describe('/', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(400);
 
         validator.validate(body, schema).should.be.true;
@@ -213,9 +205,8 @@ describe('/', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(500);
 
         body.should.equal(null); // non-json response or no schema
@@ -253,9 +244,8 @@ describe('/', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(500);
 
         validator.validate(body, schema).should.be.true;
@@ -272,9 +262,8 @@ describe('/', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(500);
 
         body.should.equal(null); // non-json response or no schema
@@ -312,9 +301,8 @@ describe('/', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(500);
 
         validator.validate(body, schema).should.be.true;
@@ -338,9 +326,8 @@ describe('/', function() {
         body: 'XML STRING GOES HERE'
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(200);
 
         body.should.equal(null); // non-json response or no schema
@@ -377,9 +364,8 @@ describe('/', function() {
         body: 'XML STRING GOES HERE'
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(200);
 
         validator.validate(body, schema).should.be.true;
@@ -402,9 +388,8 @@ describe('/', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(200);
 
         body.should.equal(null); // non-json response or no schema
@@ -443,9 +428,8 @@ describe('/', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(200);
 
         validator.validate(body, schema).should.be.true;
@@ -466,9 +450,8 @@ describe('/', function() {
         body: 'XML STRING GOES HERE'
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(400);
 
         body.should.equal(null); // non-json response or no schema
@@ -494,9 +477,8 @@ describe('/', function() {
         body: 'XML STRING GOES HERE'
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(400);
 
         validator.validate(body, schema).should.be.true;
@@ -519,9 +501,8 @@ describe('/', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(400);
 
         body.should.equal(null); // non-json response or no schema
@@ -549,9 +530,8 @@ describe('/', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(400);
 
         validator.validate(body, schema).should.be.true;
@@ -572,9 +552,8 @@ describe('/', function() {
         body: 'XML STRING GOES HERE'
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(500);
 
         body.should.equal(null); // non-json response or no schema
@@ -600,9 +579,8 @@ describe('/', function() {
         body: 'XML STRING GOES HERE'
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(500);
 
         validator.validate(body, schema).should.be.true;
@@ -625,9 +603,8 @@ describe('/', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(500);
 
         body.should.equal(null); // non-json response or no schema
@@ -655,9 +632,8 @@ describe('/', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(500);
 
         validator.validate(body, schema).should.be.true;

--- a/test/robust/compare/output15__Stub.js
+++ b/test/robust/compare/output15__Stub.js
@@ -1,0 +1,670 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+
+chai.should();
+var request = require('request');
+
+describe('/', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      request({
+        url: 'https://api.uber.com/',
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/xml'
+        }
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(200);
+
+        body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "username": {
+            "type": "string"
+          }
+        }
+      };
+      /*eslint-enable*/
+      request({
+        url: 'https://api.uber.com/',
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/xml'
+        }
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(200);
+
+        validator.validate(body, schema).should.be.true;
+        done();
+      });
+    });
+
+    it('should respond with 200 OK', function(done) {
+      request({
+        url: 'https://api.uber.com/',
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(200);
+
+        body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "username": {
+            "type": "string"
+          }
+        }
+      };
+      /*eslint-enable*/
+      request({
+        url: 'https://api.uber.com/',
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(200);
+
+        validator.validate(body, schema).should.be.true;
+        done();
+      });
+    });
+
+    it('should respond with 400 NOT OK', function(done) {
+      request({
+        url: 'https://api.uber.com/',
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/xml'
+        }
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(400);
+
+        body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 400 NOT OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "properties": {
+          "meta": "string",
+          "data": "number"
+        }
+      };
+      /*eslint-enable*/
+      request({
+        url: 'https://api.uber.com/',
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/xml'
+        }
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(400);
+
+        validator.validate(body, schema).should.be.true;
+        done();
+      });
+    });
+
+    it('should respond with 400 NOT OK', function(done) {
+      request({
+        url: 'https://api.uber.com/',
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(400);
+
+        body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 400 NOT OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "properties": {
+          "meta": "string",
+          "data": "number"
+        }
+      };
+      /*eslint-enable*/
+      request({
+        url: 'https://api.uber.com/',
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(400);
+
+        validator.validate(body, schema).should.be.true;
+        done();
+      });
+    });
+
+    it('should respond with 500 SERVER ERROR', function(done) {
+      request({
+        url: 'https://api.uber.com/',
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/xml'
+        }
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(500);
+
+        body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 500 SERVER ERROR', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "properties": {
+          "meta": "string",
+          "data": "number",
+          "UserObj": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "integer"
+                },
+                "username": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+      request({
+        url: 'https://api.uber.com/',
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/xml'
+        }
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(500);
+
+        validator.validate(body, schema).should.be.true;
+        done();
+      });
+    });
+
+    it('should respond with 500 SERVER ERROR', function(done) {
+      request({
+        url: 'https://api.uber.com/',
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(500);
+
+        body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 500 SERVER ERROR', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "properties": {
+          "meta": "string",
+          "data": "number",
+          "UserObj": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "integer"
+                },
+                "username": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+      request({
+        url: 'https://api.uber.com/',
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(500);
+
+        validator.validate(body, schema).should.be.true;
+        done();
+      });
+    });
+
+  });
+
+  describe('post', function() {
+    it('should respond with 200 OK', function(done) {
+      request({
+        url: 'https://api.uber.com/',
+        qs: {
+          longitude: 'DATA GOES HERE'
+        },
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/xml'
+        },
+        body: 'XML STRING GOES HERE'
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(200);
+
+        body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "integer"
+            },
+            "username": {
+              "type": "string"
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+      request({
+        url: 'https://api.uber.com/',
+        qs: {
+          longitude: 'DATA GOES HERE'
+        },
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/xml'
+        },
+        body: 'XML STRING GOES HERE'
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(200);
+
+        validator.validate(body, schema).should.be.true;
+        done();
+      });
+    });
+
+    it('should respond with 200 OK', function(done) {
+      request({
+        url: 'https://api.uber.com/',
+        qs: {
+          longitude: 'DATA GOES HERE'
+        },
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        json: {
+          latitude: 'DATA GOES HERE'
+        }
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(200);
+
+        body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "integer"
+            },
+            "username": {
+              "type": "string"
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+      request({
+        url: 'https://api.uber.com/',
+        qs: {
+          longitude: 'DATA GOES HERE'
+        },
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        json: {
+          latitude: 'DATA GOES HERE'
+        }
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(200);
+
+        validator.validate(body, schema).should.be.true;
+        done();
+      });
+    });
+
+    it('should respond with 400 NOT OK', function(done) {
+      request({
+        url: 'https://api.uber.com/',
+        qs: {
+          longitude: 'DATA GOES HERE'
+        },
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/xml'
+        },
+        body: 'XML STRING GOES HERE'
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(400);
+
+        body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 400 NOT OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "number"
+      };
+      /*eslint-enable*/
+      request({
+        url: 'https://api.uber.com/',
+        qs: {
+          longitude: 'DATA GOES HERE'
+        },
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/xml'
+        },
+        body: 'XML STRING GOES HERE'
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(400);
+
+        validator.validate(body, schema).should.be.true;
+        done();
+      });
+    });
+
+    it('should respond with 400 NOT OK', function(done) {
+      request({
+        url: 'https://api.uber.com/',
+        qs: {
+          longitude: 'DATA GOES HERE'
+        },
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        json: {
+          latitude: 'DATA GOES HERE'
+        }
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(400);
+
+        body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 400 NOT OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "number"
+      };
+      /*eslint-enable*/
+      request({
+        url: 'https://api.uber.com/',
+        qs: {
+          longitude: 'DATA GOES HERE'
+        },
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        json: {
+          latitude: 'DATA GOES HERE'
+        }
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(400);
+
+        validator.validate(body, schema).should.be.true;
+        done();
+      });
+    });
+
+    it('should respond with 500 SERVER ERROR', function(done) {
+      request({
+        url: 'https://api.uber.com/',
+        qs: {
+          longitude: 'DATA GOES HERE'
+        },
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/xml'
+        },
+        body: 'XML STRING GOES HERE'
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(500);
+
+        body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 500 SERVER ERROR', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "string"
+      };
+      /*eslint-enable*/
+      request({
+        url: 'https://api.uber.com/',
+        qs: {
+          longitude: 'DATA GOES HERE'
+        },
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/xml'
+        },
+        body: 'XML STRING GOES HERE'
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(500);
+
+        validator.validate(body, schema).should.be.true;
+        done();
+      });
+    });
+
+    it('should respond with 500 SERVER ERROR', function(done) {
+      request({
+        url: 'https://api.uber.com/',
+        qs: {
+          longitude: 'DATA GOES HERE'
+        },
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        json: {
+          latitude: 'DATA GOES HERE'
+        }
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(500);
+
+        body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 500 SERVER ERROR', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "string"
+      };
+      /*eslint-enable*/
+      request({
+        url: 'https://api.uber.com/',
+        qs: {
+          longitude: 'DATA GOES HERE'
+        },
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        json: {
+          latitude: 'DATA GOES HERE'
+        }
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(500);
+
+        validator.validate(body, schema).should.be.true;
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/robust/compare/output15_user_Stub.js
+++ b/test/robust/compare/output15_user_Stub.js
@@ -1,0 +1,530 @@
+'use strict';
+var chai = require('chai');
+
+chai.should();
+var request = require('request');
+
+describe('/user', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      request({
+        url: 'https://api.uber.com/user',
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/xml'
+        }
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(200);
+
+        body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 200 OK', function(done) {
+      request({
+        url: 'https://api.uber.com/user',
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/xml'
+        }
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(200);
+
+        body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 200 OK', function(done) {
+      request({
+        url: 'https://api.uber.com/user',
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(200);
+
+        body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 200 OK', function(done) {
+      request({
+        url: 'https://api.uber.com/user',
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(200);
+
+        body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 400 NOT OK', function(done) {
+      request({
+        url: 'https://api.uber.com/user',
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/xml'
+        }
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(400);
+
+        body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 400 NOT OK', function(done) {
+      request({
+        url: 'https://api.uber.com/user',
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/xml'
+        }
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(400);
+
+        body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 400 NOT OK', function(done) {
+      request({
+        url: 'https://api.uber.com/user',
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(400);
+
+        body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 400 NOT OK', function(done) {
+      request({
+        url: 'https://api.uber.com/user',
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(400);
+
+        body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 500 SERVER ERROR', function(done) {
+      request({
+        url: 'https://api.uber.com/user',
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/xml'
+        }
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(500);
+
+        body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 500 SERVER ERROR', function(done) {
+      request({
+        url: 'https://api.uber.com/user',
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/xml'
+        }
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(500);
+
+        body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 500 SERVER ERROR', function(done) {
+      request({
+        url: 'https://api.uber.com/user',
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(500);
+
+        body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 500 SERVER ERROR', function(done) {
+      request({
+        url: 'https://api.uber.com/user',
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(500);
+
+        body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+  });
+
+  describe('post', function() {
+    it('should respond with 200 OK', function(done) {
+      request({
+        url: 'https://api.uber.com/user',
+        qs: {
+          longitude: 'DATA GOES HERE'
+        },
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/xml'
+        },
+        body: 'XML STRING GOES HERE'
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(200);
+
+        body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 200 OK', function(done) {
+      request({
+        url: 'https://api.uber.com/user',
+        qs: {
+          longitude: 'DATA GOES HERE'
+        },
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/xml'
+        },
+        body: 'XML STRING GOES HERE'
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(200);
+
+        body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 200 OK', function(done) {
+      request({
+        url: 'https://api.uber.com/user',
+        qs: {
+          longitude: 'DATA GOES HERE'
+        },
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        json: {
+          latitude: 'DATA GOES HERE'
+        }
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(200);
+
+        body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 200 OK', function(done) {
+      request({
+        url: 'https://api.uber.com/user',
+        qs: {
+          longitude: 'DATA GOES HERE'
+        },
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        json: {
+          latitude: 'DATA GOES HERE'
+        }
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(200);
+
+        body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 400 NOT OK', function(done) {
+      request({
+        url: 'https://api.uber.com/user',
+        qs: {
+          longitude: 'DATA GOES HERE'
+        },
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/xml'
+        },
+        body: 'XML STRING GOES HERE'
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(400);
+
+        body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 400 NOT OK', function(done) {
+      request({
+        url: 'https://api.uber.com/user',
+        qs: {
+          longitude: 'DATA GOES HERE'
+        },
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/xml'
+        },
+        body: 'XML STRING GOES HERE'
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(400);
+
+        body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 400 NOT OK', function(done) {
+      request({
+        url: 'https://api.uber.com/user',
+        qs: {
+          longitude: 'DATA GOES HERE'
+        },
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        json: {
+          latitude: 'DATA GOES HERE'
+        }
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(400);
+
+        body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 400 NOT OK', function(done) {
+      request({
+        url: 'https://api.uber.com/user',
+        qs: {
+          longitude: 'DATA GOES HERE'
+        },
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        json: {
+          latitude: 'DATA GOES HERE'
+        }
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(400);
+
+        body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 500 SERVER ERROR', function(done) {
+      request({
+        url: 'https://api.uber.com/user',
+        qs: {
+          longitude: 'DATA GOES HERE'
+        },
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/xml'
+        },
+        body: 'XML STRING GOES HERE'
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(500);
+
+        body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 500 SERVER ERROR', function(done) {
+      request({
+        url: 'https://api.uber.com/user',
+        qs: {
+          longitude: 'DATA GOES HERE'
+        },
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/xml'
+        },
+        body: 'XML STRING GOES HERE'
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(500);
+
+        body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 500 SERVER ERROR', function(done) {
+      request({
+        url: 'https://api.uber.com/user',
+        qs: {
+          longitude: 'DATA GOES HERE'
+        },
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        json: {
+          latitude: 'DATA GOES HERE'
+        }
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(500);
+
+        body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 500 SERVER ERROR', function(done) {
+      request({
+        url: 'https://api.uber.com/user',
+        qs: {
+          longitude: 'DATA GOES HERE'
+        },
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        json: {
+          latitude: 'DATA GOES HERE'
+        }
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(500);
+
+        body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/robust/compare/output15_user_Stub.js
+++ b/test/robust/compare/output15_user_Stub.js
@@ -15,9 +15,8 @@ describe('/user', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(200);
 
         body.should.equal(null); // non-json response or no schema
@@ -34,9 +33,8 @@ describe('/user', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(200);
 
         body.should.equal(null); // non-json response or no schema
@@ -53,9 +51,8 @@ describe('/user', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(200);
 
         body.should.equal(null); // non-json response or no schema
@@ -72,9 +69,8 @@ describe('/user', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(200);
 
         body.should.equal(null); // non-json response or no schema
@@ -91,9 +87,8 @@ describe('/user', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(400);
 
         body.should.equal(null); // non-json response or no schema
@@ -110,9 +105,8 @@ describe('/user', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(400);
 
         body.should.equal(null); // non-json response or no schema
@@ -129,9 +123,8 @@ describe('/user', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(400);
 
         body.should.equal(null); // non-json response or no schema
@@ -148,9 +141,8 @@ describe('/user', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(400);
 
         body.should.equal(null); // non-json response or no schema
@@ -167,9 +159,8 @@ describe('/user', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(500);
 
         body.should.equal(null); // non-json response or no schema
@@ -186,9 +177,8 @@ describe('/user', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(500);
 
         body.should.equal(null); // non-json response or no schema
@@ -205,9 +195,8 @@ describe('/user', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(500);
 
         body.should.equal(null); // non-json response or no schema
@@ -224,9 +213,8 @@ describe('/user', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(500);
 
         body.should.equal(null); // non-json response or no schema
@@ -250,9 +238,8 @@ describe('/user', function() {
         body: 'XML STRING GOES HERE'
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(200);
 
         body.should.equal(null); // non-json response or no schema
@@ -273,34 +260,8 @@ describe('/user', function() {
         body: 'XML STRING GOES HERE'
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
-        res.statusCode.should.equal(200);
+        if (error) return done(error);
 
-        body.should.equal(null); // non-json response or no schema
-        done();
-      });
-    });
-
-    it('should respond with 200 OK', function(done) {
-      request({
-        url: 'https://api.uber.com/user',
-        qs: {
-          longitude: 'DATA GOES HERE'
-        },
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json'
-        },
-        json: {
-          latitude: 'DATA GOES HERE'
-        }
-      },
-      function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
         res.statusCode.should.equal(200);
 
         body.should.equal(null); // non-json response or no schema
@@ -323,9 +284,32 @@ describe('/user', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
+        if (error) return done(error);
+
+        res.statusCode.should.equal(200);
+
+        body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 200 OK', function(done) {
+      request({
+        url: 'https://api.uber.com/user',
+        qs: {
+          longitude: 'DATA GOES HERE'
+        },
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        json: {
+          latitude: 'DATA GOES HERE'
         }
+      },
+      function(error, res, body) {
+        if (error) return done(error);
+
         res.statusCode.should.equal(200);
 
         body.should.equal(null); // non-json response or no schema
@@ -346,9 +330,8 @@ describe('/user', function() {
         body: 'XML STRING GOES HERE'
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(400);
 
         body.should.equal(null); // non-json response or no schema
@@ -369,34 +352,8 @@ describe('/user', function() {
         body: 'XML STRING GOES HERE'
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
-        res.statusCode.should.equal(400);
+        if (error) return done(error);
 
-        body.should.equal(null); // non-json response or no schema
-        done();
-      });
-    });
-
-    it('should respond with 400 NOT OK', function(done) {
-      request({
-        url: 'https://api.uber.com/user',
-        qs: {
-          longitude: 'DATA GOES HERE'
-        },
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json'
-        },
-        json: {
-          latitude: 'DATA GOES HERE'
-        }
-      },
-      function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
         res.statusCode.should.equal(400);
 
         body.should.equal(null); // non-json response or no schema
@@ -419,9 +376,32 @@ describe('/user', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
+        if (error) return done(error);
+
+        res.statusCode.should.equal(400);
+
+        body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 400 NOT OK', function(done) {
+      request({
+        url: 'https://api.uber.com/user',
+        qs: {
+          longitude: 'DATA GOES HERE'
+        },
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        json: {
+          latitude: 'DATA GOES HERE'
         }
+      },
+      function(error, res, body) {
+        if (error) return done(error);
+
         res.statusCode.should.equal(400);
 
         body.should.equal(null); // non-json response or no schema
@@ -442,9 +422,8 @@ describe('/user', function() {
         body: 'XML STRING GOES HERE'
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(500);
 
         body.should.equal(null); // non-json response or no schema
@@ -465,9 +444,8 @@ describe('/user', function() {
         body: 'XML STRING GOES HERE'
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(500);
 
         body.should.equal(null); // non-json response or no schema
@@ -490,9 +468,8 @@ describe('/user', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(500);
 
         body.should.equal(null); // non-json response or no schema
@@ -515,9 +492,8 @@ describe('/user', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(500);
 
         body.should.equal(null); // non-json response or no schema

--- a/test/robust/compare/output16__Stub.js
+++ b/test/robust/compare/output16__Stub.js
@@ -1,0 +1,272 @@
+'use strict';
+var chai = require('chai');
+
+chai.should();
+var request = require('request');
+
+describe('/', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      request({
+        url: 'https://api.uber.com/',
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/xml'
+        }
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(200);
+
+        body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 200 OK', function(done) {
+      request({
+        url: 'https://api.uber.com/',
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(200);
+
+        body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 400 NOT OK', function(done) {
+      request({
+        url: 'https://api.uber.com/',
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/xml'
+        }
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(400);
+
+        body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 400 NOT OK', function(done) {
+      request({
+        url: 'https://api.uber.com/',
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(400);
+
+        body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 500 SERVER ERROR', function(done) {
+      request({
+        url: 'https://api.uber.com/',
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/xml'
+        }
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(500);
+
+        body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 500 SERVER ERROR', function(done) {
+      request({
+        url: 'https://api.uber.com/',
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(500);
+
+        body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+  });
+
+  describe('post', function() {
+    it('should respond with 200 OK', function(done) {
+      request({
+        url: 'https://api.uber.com/',
+        qs: {
+          longitude: 'DATA GOES HERE'
+        },
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/xml'
+        },
+        body: 'XML STRING GOES HERE'
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(200);
+
+        body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 200 OK', function(done) {
+      request({
+        url: 'https://api.uber.com/',
+        qs: {
+          longitude: 'DATA GOES HERE'
+        },
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        json: {
+          latitude: 'DATA GOES HERE'
+        }
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(200);
+
+        body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 400 NOT OK', function(done) {
+      request({
+        url: 'https://api.uber.com/',
+        qs: {
+          longitude: 'DATA GOES HERE'
+        },
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/xml'
+        },
+        body: 'XML STRING GOES HERE'
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(400);
+
+        body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 400 NOT OK', function(done) {
+      request({
+        url: 'https://api.uber.com/',
+        qs: {
+          longitude: 'DATA GOES HERE'
+        },
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        json: {
+          latitude: 'DATA GOES HERE'
+        }
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(400);
+
+        body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 500 SERVER ERROR', function(done) {
+      request({
+        url: 'https://api.uber.com/',
+        qs: {
+          longitude: 'DATA GOES HERE'
+        },
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/xml'
+        },
+        body: 'XML STRING GOES HERE'
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(500);
+
+        body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 500 SERVER ERROR', function(done) {
+      request({
+        url: 'https://api.uber.com/',
+        qs: {
+          longitude: 'DATA GOES HERE'
+        },
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        json: {
+          latitude: 'DATA GOES HERE'
+        }
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(500);
+
+        body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/robust/compare/output16__Stub.js
+++ b/test/robust/compare/output16__Stub.js
@@ -15,9 +15,8 @@ describe('/', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(200);
 
         body.should.equal(null); // non-json response or no schema
@@ -34,9 +33,8 @@ describe('/', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(200);
 
         body.should.equal(null); // non-json response or no schema
@@ -53,9 +51,8 @@ describe('/', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(400);
 
         body.should.equal(null); // non-json response or no schema
@@ -72,9 +69,8 @@ describe('/', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(400);
 
         body.should.equal(null); // non-json response or no schema
@@ -91,9 +87,8 @@ describe('/', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(500);
 
         body.should.equal(null); // non-json response or no schema
@@ -110,9 +105,8 @@ describe('/', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(500);
 
         body.should.equal(null); // non-json response or no schema
@@ -136,9 +130,8 @@ describe('/', function() {
         body: 'XML STRING GOES HERE'
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(200);
 
         body.should.equal(null); // non-json response or no schema
@@ -161,9 +154,8 @@ describe('/', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(200);
 
         body.should.equal(null); // non-json response or no schema
@@ -184,9 +176,8 @@ describe('/', function() {
         body: 'XML STRING GOES HERE'
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(400);
 
         body.should.equal(null); // non-json response or no schema
@@ -209,9 +200,8 @@ describe('/', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(400);
 
         body.should.equal(null); // non-json response or no schema
@@ -232,9 +222,8 @@ describe('/', function() {
         body: 'XML STRING GOES HERE'
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(500);
 
         body.should.equal(null); // non-json response or no schema
@@ -257,9 +246,8 @@ describe('/', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(500);
 
         body.should.equal(null); // non-json response or no schema

--- a/test/robust/compare/output16_user_Stub.js
+++ b/test/robust/compare/output16_user_Stub.js
@@ -1,0 +1,272 @@
+'use strict';
+var chai = require('chai');
+
+chai.should();
+var request = require('request');
+
+describe('/user', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      request({
+        url: 'https://api.uber.com/user',
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/xml'
+        }
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(200);
+
+        body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 200 OK', function(done) {
+      request({
+        url: 'https://api.uber.com/user',
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(200);
+
+        body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 400 NOT OK', function(done) {
+      request({
+        url: 'https://api.uber.com/user',
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/xml'
+        }
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(400);
+
+        body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 400 NOT OK', function(done) {
+      request({
+        url: 'https://api.uber.com/user',
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(400);
+
+        body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 500 SERVER ERROR', function(done) {
+      request({
+        url: 'https://api.uber.com/user',
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/xml'
+        }
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(500);
+
+        body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 500 SERVER ERROR', function(done) {
+      request({
+        url: 'https://api.uber.com/user',
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(500);
+
+        body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+  });
+
+  describe('post', function() {
+    it('should respond with 200 OK', function(done) {
+      request({
+        url: 'https://api.uber.com/user',
+        qs: {
+          longitude: 'DATA GOES HERE'
+        },
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/xml'
+        },
+        body: 'XML STRING GOES HERE'
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(200);
+
+        body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 200 OK', function(done) {
+      request({
+        url: 'https://api.uber.com/user',
+        qs: {
+          longitude: 'DATA GOES HERE'
+        },
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        json: {
+          latitude: 'DATA GOES HERE'
+        }
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(200);
+
+        body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 400 NOT OK', function(done) {
+      request({
+        url: 'https://api.uber.com/user',
+        qs: {
+          longitude: 'DATA GOES HERE'
+        },
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/xml'
+        },
+        body: 'XML STRING GOES HERE'
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(400);
+
+        body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 400 NOT OK', function(done) {
+      request({
+        url: 'https://api.uber.com/user',
+        qs: {
+          longitude: 'DATA GOES HERE'
+        },
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        json: {
+          latitude: 'DATA GOES HERE'
+        }
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(400);
+
+        body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 500 SERVER ERROR', function(done) {
+      request({
+        url: 'https://api.uber.com/user',
+        qs: {
+          longitude: 'DATA GOES HERE'
+        },
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/xml'
+        },
+        body: 'XML STRING GOES HERE'
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(500);
+
+        body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 500 SERVER ERROR', function(done) {
+      request({
+        url: 'https://api.uber.com/user',
+        qs: {
+          longitude: 'DATA GOES HERE'
+        },
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        json: {
+          latitude: 'DATA GOES HERE'
+        }
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(500);
+
+        body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/robust/compare/output16_user_Stub.js
+++ b/test/robust/compare/output16_user_Stub.js
@@ -15,9 +15,8 @@ describe('/user', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(200);
 
         body.should.equal(null); // non-json response or no schema
@@ -34,9 +33,8 @@ describe('/user', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(200);
 
         body.should.equal(null); // non-json response or no schema
@@ -53,9 +51,8 @@ describe('/user', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(400);
 
         body.should.equal(null); // non-json response or no schema
@@ -72,9 +69,8 @@ describe('/user', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(400);
 
         body.should.equal(null); // non-json response or no schema
@@ -91,9 +87,8 @@ describe('/user', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(500);
 
         body.should.equal(null); // non-json response or no schema
@@ -110,9 +105,8 @@ describe('/user', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(500);
 
         body.should.equal(null); // non-json response or no schema
@@ -136,9 +130,8 @@ describe('/user', function() {
         body: 'XML STRING GOES HERE'
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(200);
 
         body.should.equal(null); // non-json response or no schema
@@ -161,9 +154,8 @@ describe('/user', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(200);
 
         body.should.equal(null); // non-json response or no schema
@@ -184,9 +176,8 @@ describe('/user', function() {
         body: 'XML STRING GOES HERE'
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(400);
 
         body.should.equal(null); // non-json response or no schema
@@ -209,9 +200,8 @@ describe('/user', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(400);
 
         body.should.equal(null); // non-json response or no schema
@@ -232,9 +222,8 @@ describe('/user', function() {
         body: 'XML STRING GOES HERE'
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(500);
 
         body.should.equal(null); // non-json response or no schema
@@ -257,9 +246,8 @@ describe('/user', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(500);
 
         body.should.equal(null); // non-json response or no schema

--- a/test/robust/compare/output17__Stub.js
+++ b/test/robust/compare/output17__Stub.js
@@ -1,0 +1,412 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+
+chai.should();
+var request = require('request');
+
+describe('/', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "username": {
+            "type": "string"
+          }
+        }
+      };
+      /*eslint-enable*/
+      request({
+        url: 'https://api.uber.com/',
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/xml'
+        }
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(200);
+
+        validator.validate(body, schema).should.be.true;
+        done();
+      });
+    });
+
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "username": {
+            "type": "string"
+          }
+        }
+      };
+      /*eslint-enable*/
+      request({
+        url: 'https://api.uber.com/',
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(200);
+
+        validator.validate(body, schema).should.be.true;
+        done();
+      });
+    });
+
+    it('should respond with 400 NOT OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "properties": {
+          "meta": "string",
+          "data": "number"
+        }
+      };
+      /*eslint-enable*/
+      request({
+        url: 'https://api.uber.com/',
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/xml'
+        }
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(400);
+
+        validator.validate(body, schema).should.be.true;
+        done();
+      });
+    });
+
+    it('should respond with 400 NOT OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "properties": {
+          "meta": "string",
+          "data": "number"
+        }
+      };
+      /*eslint-enable*/
+      request({
+        url: 'https://api.uber.com/',
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(400);
+
+        validator.validate(body, schema).should.be.true;
+        done();
+      });
+    });
+
+    it('should respond with 500 SERVER ERROR', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "properties": {
+          "meta": "string",
+          "data": "number",
+          "UserObj": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "integer"
+                },
+                "username": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+      request({
+        url: 'https://api.uber.com/',
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/xml'
+        }
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(500);
+
+        validator.validate(body, schema).should.be.true;
+        done();
+      });
+    });
+
+    it('should respond with 500 SERVER ERROR', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "properties": {
+          "meta": "string",
+          "data": "number",
+          "UserObj": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "integer"
+                },
+                "username": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+      request({
+        url: 'https://api.uber.com/',
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(500);
+
+        validator.validate(body, schema).should.be.true;
+        done();
+      });
+    });
+
+  });
+
+  describe('post', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "integer"
+            },
+            "username": {
+              "type": "string"
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+      request({
+        url: 'https://api.uber.com/',
+        qs: {
+          longitude: 'DATA GOES HERE'
+        },
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/xml'
+        },
+        body: 'XML STRING GOES HERE'
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(200);
+
+        validator.validate(body, schema).should.be.true;
+        done();
+      });
+    });
+
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "integer"
+            },
+            "username": {
+              "type": "string"
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+      request({
+        url: 'https://api.uber.com/',
+        qs: {
+          longitude: 'DATA GOES HERE'
+        },
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        json: {
+          latitude: 'DATA GOES HERE'
+        }
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(200);
+
+        validator.validate(body, schema).should.be.true;
+        done();
+      });
+    });
+
+    it('should respond with 400 NOT OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "number"
+      };
+      /*eslint-enable*/
+      request({
+        url: 'https://api.uber.com/',
+        qs: {
+          longitude: 'DATA GOES HERE'
+        },
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/xml'
+        },
+        body: 'XML STRING GOES HERE'
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(400);
+
+        validator.validate(body, schema).should.be.true;
+        done();
+      });
+    });
+
+    it('should respond with 400 NOT OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "number"
+      };
+      /*eslint-enable*/
+      request({
+        url: 'https://api.uber.com/',
+        qs: {
+          longitude: 'DATA GOES HERE'
+        },
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        json: {
+          latitude: 'DATA GOES HERE'
+        }
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(400);
+
+        validator.validate(body, schema).should.be.true;
+        done();
+      });
+    });
+
+    it('should respond with 500 SERVER ERROR', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "string"
+      };
+      /*eslint-enable*/
+      request({
+        url: 'https://api.uber.com/',
+        qs: {
+          longitude: 'DATA GOES HERE'
+        },
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/xml'
+        },
+        body: 'XML STRING GOES HERE'
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(500);
+
+        validator.validate(body, schema).should.be.true;
+        done();
+      });
+    });
+
+    it('should respond with 500 SERVER ERROR', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "string"
+      };
+      /*eslint-enable*/
+      request({
+        url: 'https://api.uber.com/',
+        qs: {
+          longitude: 'DATA GOES HERE'
+        },
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        json: {
+          latitude: 'DATA GOES HERE'
+        }
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(500);
+
+        validator.validate(body, schema).should.be.true;
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/robust/compare/output17__Stub.js
+++ b/test/robust/compare/output17__Stub.js
@@ -30,9 +30,8 @@ describe('/', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(200);
 
         validator.validate(body, schema).should.be.true;
@@ -62,9 +61,8 @@ describe('/', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(200);
 
         validator.validate(body, schema).should.be.true;
@@ -90,9 +88,8 @@ describe('/', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(400);
 
         validator.validate(body, schema).should.be.true;
@@ -118,9 +115,8 @@ describe('/', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(400);
 
         validator.validate(body, schema).should.be.true;
@@ -158,9 +154,8 @@ describe('/', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(500);
 
         validator.validate(body, schema).should.be.true;
@@ -198,9 +193,8 @@ describe('/', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(500);
 
         validator.validate(body, schema).should.be.true;
@@ -240,9 +234,8 @@ describe('/', function() {
         body: 'XML STRING GOES HERE'
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(200);
 
         validator.validate(body, schema).should.be.true;
@@ -281,9 +274,8 @@ describe('/', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(200);
 
         validator.validate(body, schema).should.be.true;
@@ -309,9 +301,8 @@ describe('/', function() {
         body: 'XML STRING GOES HERE'
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(400);
 
         validator.validate(body, schema).should.be.true;
@@ -339,9 +330,8 @@ describe('/', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(400);
 
         validator.validate(body, schema).should.be.true;
@@ -367,9 +357,8 @@ describe('/', function() {
         body: 'XML STRING GOES HERE'
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(500);
 
         validator.validate(body, schema).should.be.true;
@@ -397,9 +386,8 @@ describe('/', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(500);
 
         validator.validate(body, schema).should.be.true;

--- a/test/robust/compare/output17_user_Stub.js
+++ b/test/robust/compare/output17_user_Stub.js
@@ -1,0 +1,272 @@
+'use strict';
+var chai = require('chai');
+
+chai.should();
+var request = require('request');
+
+describe('/user', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      request({
+        url: 'https://api.uber.com/user',
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/xml'
+        }
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(200);
+
+        body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 200 OK', function(done) {
+      request({
+        url: 'https://api.uber.com/user',
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(200);
+
+        body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 400 NOT OK', function(done) {
+      request({
+        url: 'https://api.uber.com/user',
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/xml'
+        }
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(400);
+
+        body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 400 NOT OK', function(done) {
+      request({
+        url: 'https://api.uber.com/user',
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(400);
+
+        body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 500 SERVER ERROR', function(done) {
+      request({
+        url: 'https://api.uber.com/user',
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/xml'
+        }
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(500);
+
+        body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 500 SERVER ERROR', function(done) {
+      request({
+        url: 'https://api.uber.com/user',
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(500);
+
+        body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+  });
+
+  describe('post', function() {
+    it('should respond with 200 OK', function(done) {
+      request({
+        url: 'https://api.uber.com/user',
+        qs: {
+          longitude: 'DATA GOES HERE'
+        },
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/xml'
+        },
+        body: 'XML STRING GOES HERE'
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(200);
+
+        body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 200 OK', function(done) {
+      request({
+        url: 'https://api.uber.com/user',
+        qs: {
+          longitude: 'DATA GOES HERE'
+        },
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        json: {
+          latitude: 'DATA GOES HERE'
+        }
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(200);
+
+        body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 400 NOT OK', function(done) {
+      request({
+        url: 'https://api.uber.com/user',
+        qs: {
+          longitude: 'DATA GOES HERE'
+        },
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/xml'
+        },
+        body: 'XML STRING GOES HERE'
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(400);
+
+        body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 400 NOT OK', function(done) {
+      request({
+        url: 'https://api.uber.com/user',
+        qs: {
+          longitude: 'DATA GOES HERE'
+        },
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        json: {
+          latitude: 'DATA GOES HERE'
+        }
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(400);
+
+        body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 500 SERVER ERROR', function(done) {
+      request({
+        url: 'https://api.uber.com/user',
+        qs: {
+          longitude: 'DATA GOES HERE'
+        },
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/xml'
+        },
+        body: 'XML STRING GOES HERE'
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(500);
+
+        body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 500 SERVER ERROR', function(done) {
+      request({
+        url: 'https://api.uber.com/user',
+        qs: {
+          longitude: 'DATA GOES HERE'
+        },
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        json: {
+          latitude: 'DATA GOES HERE'
+        }
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(500);
+
+        body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/robust/compare/output17_user_Stub.js
+++ b/test/robust/compare/output17_user_Stub.js
@@ -15,9 +15,8 @@ describe('/user', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(200);
 
         body.should.equal(null); // non-json response or no schema
@@ -34,9 +33,8 @@ describe('/user', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(200);
 
         body.should.equal(null); // non-json response or no schema
@@ -53,9 +51,8 @@ describe('/user', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(400);
 
         body.should.equal(null); // non-json response or no schema
@@ -72,9 +69,8 @@ describe('/user', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(400);
 
         body.should.equal(null); // non-json response or no schema
@@ -91,9 +87,8 @@ describe('/user', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(500);
 
         body.should.equal(null); // non-json response or no schema
@@ -110,9 +105,8 @@ describe('/user', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(500);
 
         body.should.equal(null); // non-json response or no schema
@@ -136,9 +130,8 @@ describe('/user', function() {
         body: 'XML STRING GOES HERE'
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(200);
 
         body.should.equal(null); // non-json response or no schema
@@ -161,9 +154,8 @@ describe('/user', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(200);
 
         body.should.equal(null); // non-json response or no schema
@@ -184,9 +176,8 @@ describe('/user', function() {
         body: 'XML STRING GOES HERE'
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(400);
 
         body.should.equal(null); // non-json response or no schema
@@ -209,9 +200,8 @@ describe('/user', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(400);
 
         body.should.equal(null); // non-json response or no schema
@@ -232,9 +222,8 @@ describe('/user', function() {
         body: 'XML STRING GOES HERE'
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(500);
 
         body.should.equal(null); // non-json response or no schema
@@ -257,9 +246,8 @@ describe('/user', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(500);
 
         body.should.equal(null); // non-json response or no schema

--- a/test/robust/compare/output18__Stub.js
+++ b/test/robust/compare/output18__Stub.js
@@ -30,9 +30,8 @@ describe('/', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(200);
 
         validator.validate(body, schema).should.be.true;
@@ -58,9 +57,8 @@ describe('/', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(400);
 
         validator.validate(body, schema).should.be.true;
@@ -98,9 +96,8 @@ describe('/', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(500);
 
         validator.validate(body, schema).should.be.true;
@@ -140,9 +137,8 @@ describe('/', function() {
         body: 'XML STRING GOES HERE'
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(200);
 
         validator.validate(body, schema).should.be.true;
@@ -168,9 +164,8 @@ describe('/', function() {
         body: 'XML STRING GOES HERE'
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(400);
 
         validator.validate(body, schema).should.be.true;
@@ -196,9 +191,8 @@ describe('/', function() {
         body: 'XML STRING GOES HERE'
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(500);
 
         validator.validate(body, schema).should.be.true;

--- a/test/robust/compare/output18__Stub.js
+++ b/test/robust/compare/output18__Stub.js
@@ -1,0 +1,211 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+
+chai.should();
+var request = require('request');
+
+describe('/', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "username": {
+            "type": "string"
+          }
+        }
+      };
+      /*eslint-enable*/
+      request({
+        url: 'https://api.uber.com/',
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/xml'
+        }
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(200);
+
+        validator.validate(body, schema).should.be.true;
+        done();
+      });
+    });
+
+    it('should respond with 400 NOT OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "properties": {
+          "meta": "string",
+          "data": "number"
+        }
+      };
+      /*eslint-enable*/
+      request({
+        url: 'https://api.uber.com/',
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/xml'
+        }
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(400);
+
+        validator.validate(body, schema).should.be.true;
+        done();
+      });
+    });
+
+    it('should respond with 500 SERVER ERROR', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "properties": {
+          "meta": "string",
+          "data": "number",
+          "UserObj": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "integer"
+                },
+                "username": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+      request({
+        url: 'https://api.uber.com/',
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/xml'
+        }
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(500);
+
+        validator.validate(body, schema).should.be.true;
+        done();
+      });
+    });
+
+  });
+
+  describe('post', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "integer"
+            },
+            "username": {
+              "type": "string"
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+      request({
+        url: 'https://api.uber.com/',
+        qs: {
+          longitude: 'DATA GOES HERE'
+        },
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/xml'
+        },
+        body: 'XML STRING GOES HERE'
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(200);
+
+        validator.validate(body, schema).should.be.true;
+        done();
+      });
+    });
+
+    it('should respond with 400 NOT OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "number"
+      };
+      /*eslint-enable*/
+      request({
+        url: 'https://api.uber.com/',
+        qs: {
+          longitude: 'DATA GOES HERE'
+        },
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/xml'
+        },
+        body: 'XML STRING GOES HERE'
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(400);
+
+        validator.validate(body, schema).should.be.true;
+        done();
+      });
+    });
+
+    it('should respond with 500 SERVER ERROR', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "string"
+      };
+      /*eslint-enable*/
+      request({
+        url: 'https://api.uber.com/',
+        qs: {
+          longitude: 'DATA GOES HERE'
+        },
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/xml'
+        },
+        body: 'XML STRING GOES HERE'
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(500);
+
+        validator.validate(body, schema).should.be.true;
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/robust/compare/output18_user_Stub.js
+++ b/test/robust/compare/output18_user_Stub.js
@@ -1,0 +1,140 @@
+'use strict';
+var chai = require('chai');
+
+chai.should();
+var request = require('request');
+
+describe('/user', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      request({
+        url: 'https://api.uber.com/user',
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/xml'
+        }
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(200);
+
+        body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 400 NOT OK', function(done) {
+      request({
+        url: 'https://api.uber.com/user',
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/xml'
+        }
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(400);
+
+        body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 500 SERVER ERROR', function(done) {
+      request({
+        url: 'https://api.uber.com/user',
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/xml'
+        }
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(500);
+
+        body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+  });
+
+  describe('post', function() {
+    it('should respond with 200 OK', function(done) {
+      request({
+        url: 'https://api.uber.com/user',
+        qs: {
+          longitude: 'DATA GOES HERE'
+        },
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/xml'
+        },
+        body: 'XML STRING GOES HERE'
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(200);
+
+        body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 400 NOT OK', function(done) {
+      request({
+        url: 'https://api.uber.com/user',
+        qs: {
+          longitude: 'DATA GOES HERE'
+        },
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/xml'
+        },
+        body: 'XML STRING GOES HERE'
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(400);
+
+        body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 500 SERVER ERROR', function(done) {
+      request({
+        url: 'https://api.uber.com/user',
+        qs: {
+          longitude: 'DATA GOES HERE'
+        },
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/xml'
+        },
+        body: 'XML STRING GOES HERE'
+      },
+      function(error, res, body) {
+        if (error) {
+          return done(error);
+        }
+        res.statusCode.should.equal(500);
+
+        body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/robust/compare/output18_user_Stub.js
+++ b/test/robust/compare/output18_user_Stub.js
@@ -15,9 +15,8 @@ describe('/user', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(200);
 
         body.should.equal(null); // non-json response or no schema
@@ -34,9 +33,8 @@ describe('/user', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(400);
 
         body.should.equal(null); // non-json response or no schema
@@ -53,9 +51,8 @@ describe('/user', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(500);
 
         body.should.equal(null); // non-json response or no schema
@@ -79,9 +76,8 @@ describe('/user', function() {
         body: 'XML STRING GOES HERE'
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(200);
 
         body.should.equal(null); // non-json response or no schema
@@ -102,9 +98,8 @@ describe('/user', function() {
         body: 'XML STRING GOES HERE'
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(400);
 
         body.should.equal(null); // non-json response or no schema
@@ -125,9 +120,8 @@ describe('/user', function() {
         body: 'XML STRING GOES HERE'
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(500);
 
         body.should.equal(null); // non-json response or no schema

--- a/test/robust/compare/output1__Stub.js
+++ b/test/robust/compare/output1__Stub.js
@@ -30,9 +30,8 @@ describe('/', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(200);
 
         validator.validate(body, schema).should.be.true;
@@ -58,9 +57,8 @@ describe('/', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(400);
 
         validator.validate(body, schema).should.be.true;
@@ -98,9 +96,8 @@ describe('/', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(500);
 
         validator.validate(body, schema).should.be.true;
@@ -142,9 +139,8 @@ describe('/', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(200);
 
         validator.validate(body, schema).should.be.true;
@@ -172,9 +168,8 @@ describe('/', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(400);
 
         validator.validate(body, schema).should.be.true;
@@ -202,9 +197,8 @@ describe('/', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(500);
 
         validator.validate(body, schema).should.be.true;

--- a/test/robust/compare/output1__Stub.js
+++ b/test/robust/compare/output1__Stub.js
@@ -23,7 +23,7 @@ describe('/', function() {
       };
       /*eslint-enable*/
       request({
-        url: 'https://api.uber.com/test/',
+        url: 'https://api.uber.com/',
         method: 'GET',
         headers: {
           'Content-Type': 'application/json'
@@ -33,6 +33,8 @@ describe('/', function() {
         if (error) {
           return done(error);
         }
+        res.statusCode.should.equal(200);
+
         validator.validate(body, schema).should.be.true;
         done();
       });
@@ -49,7 +51,7 @@ describe('/', function() {
       };
       /*eslint-enable*/
       request({
-        url: 'https://api.uber.com/test/',
+        url: 'https://api.uber.com/',
         method: 'GET',
         headers: {
           'Content-Type': 'application/json'
@@ -59,6 +61,8 @@ describe('/', function() {
         if (error) {
           return done(error);
         }
+        res.statusCode.should.equal(400);
+
         validator.validate(body, schema).should.be.true;
         done();
       });
@@ -87,7 +91,7 @@ describe('/', function() {
       };
       /*eslint-enable*/
       request({
-        url: 'https://api.uber.com/test/',
+        url: 'https://api.uber.com/',
         method: 'GET',
         headers: {
           'Content-Type': 'application/json'
@@ -97,6 +101,8 @@ describe('/', function() {
         if (error) {
           return done(error);
         }
+        res.statusCode.should.equal(500);
+
         validator.validate(body, schema).should.be.true;
         done();
       });
@@ -123,7 +129,7 @@ describe('/', function() {
       };
       /*eslint-enable*/
       request({
-        url: 'https://api.uber.com/test/',
+        url: 'https://api.uber.com/',
         qs: {
           longitude: 'DATA GOES HERE'
         },
@@ -139,6 +145,8 @@ describe('/', function() {
         if (error) {
           return done(error);
         }
+        res.statusCode.should.equal(200);
+
         validator.validate(body, schema).should.be.true;
         done();
       });
@@ -151,7 +159,7 @@ describe('/', function() {
       };
       /*eslint-enable*/
       request({
-        url: 'https://api.uber.com/test/',
+        url: 'https://api.uber.com/',
         qs: {
           longitude: 'DATA GOES HERE'
         },
@@ -167,6 +175,8 @@ describe('/', function() {
         if (error) {
           return done(error);
         }
+        res.statusCode.should.equal(400);
+
         validator.validate(body, schema).should.be.true;
         done();
       });
@@ -179,7 +189,7 @@ describe('/', function() {
       };
       /*eslint-enable*/
       request({
-        url: 'https://api.uber.com/test/',
+        url: 'https://api.uber.com/',
         qs: {
           longitude: 'DATA GOES HERE'
         },
@@ -195,6 +205,8 @@ describe('/', function() {
         if (error) {
           return done(error);
         }
+        res.statusCode.should.equal(500);
+
         validator.validate(body, schema).should.be.true;
         done();
       });

--- a/test/robust/compare/output1_user_Stub.js
+++ b/test/robust/compare/output1_user_Stub.js
@@ -8,7 +8,7 @@ describe('/user', function() {
   describe('get', function() {
     it('should respond with 200 OK', function(done) {
       request({
-        url: 'https://api.uber.com/test/user',
+        url: 'https://api.uber.com/user',
         method: 'GET',
         headers: {
           'Content-Type': 'application/json'
@@ -18,14 +18,16 @@ describe('/user', function() {
         if (error) {
           return done(error);
         }
-        body.should.equal(null);
+        res.statusCode.should.equal(200);
+
+        body.should.equal(null); // non-json response or no schema
         done();
       });
     });
 
     it('should respond with 400 NOT OK', function(done) {
       request({
-        url: 'https://api.uber.com/test/user',
+        url: 'https://api.uber.com/user',
         method: 'GET',
         headers: {
           'Content-Type': 'application/json'
@@ -35,14 +37,16 @@ describe('/user', function() {
         if (error) {
           return done(error);
         }
-        body.should.equal(null);
+        res.statusCode.should.equal(400);
+
+        body.should.equal(null); // non-json response or no schema
         done();
       });
     });
 
     it('should respond with 500 SERVER ERROR', function(done) {
       request({
-        url: 'https://api.uber.com/test/user',
+        url: 'https://api.uber.com/user',
         method: 'GET',
         headers: {
           'Content-Type': 'application/json'
@@ -52,7 +56,9 @@ describe('/user', function() {
         if (error) {
           return done(error);
         }
-        body.should.equal(null);
+        res.statusCode.should.equal(500);
+
+        body.should.equal(null); // non-json response or no schema
         done();
       });
     });
@@ -62,7 +68,7 @@ describe('/user', function() {
   describe('post', function() {
     it('should respond with 200 OK', function(done) {
       request({
-        url: 'https://api.uber.com/test/user',
+        url: 'https://api.uber.com/user',
         qs: {
           longitude: 'DATA GOES HERE'
         },
@@ -78,14 +84,16 @@ describe('/user', function() {
         if (error) {
           return done(error);
         }
-        body.should.equal(null);
+        res.statusCode.should.equal(200);
+
+        body.should.equal(null); // non-json response or no schema
         done();
       });
     });
 
     it('should respond with 400 NOT OK', function(done) {
       request({
-        url: 'https://api.uber.com/test/user',
+        url: 'https://api.uber.com/user',
         qs: {
           longitude: 'DATA GOES HERE'
         },
@@ -101,14 +109,16 @@ describe('/user', function() {
         if (error) {
           return done(error);
         }
-        body.should.equal(null);
+        res.statusCode.should.equal(400);
+
+        body.should.equal(null); // non-json response or no schema
         done();
       });
     });
 
     it('should respond with 500 SERVER ERROR', function(done) {
       request({
-        url: 'https://api.uber.com/test/user',
+        url: 'https://api.uber.com/user',
         qs: {
           longitude: 'DATA GOES HERE'
         },
@@ -124,7 +134,9 @@ describe('/user', function() {
         if (error) {
           return done(error);
         }
-        body.should.equal(null);
+        res.statusCode.should.equal(500);
+
+        body.should.equal(null); // non-json response or no schema
         done();
       });
     });

--- a/test/robust/compare/output1_user_Stub.js
+++ b/test/robust/compare/output1_user_Stub.js
@@ -15,9 +15,8 @@ describe('/user', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(200);
 
         body.should.equal(null); // non-json response or no schema
@@ -34,9 +33,8 @@ describe('/user', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(400);
 
         body.should.equal(null); // non-json response or no schema
@@ -53,9 +51,8 @@ describe('/user', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(500);
 
         body.should.equal(null); // non-json response or no schema
@@ -81,9 +78,8 @@ describe('/user', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(200);
 
         body.should.equal(null); // non-json response or no schema
@@ -106,9 +102,8 @@ describe('/user', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(400);
 
         body.should.equal(null); // non-json response or no schema
@@ -131,9 +126,8 @@ describe('/user', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(500);
 
         body.should.equal(null); // non-json response or no schema

--- a/test/robust/compare/output2__Stub.js
+++ b/test/robust/compare/output2__Stub.js
@@ -30,9 +30,8 @@ describe('/', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(200);
 
         validator.validate(body, schema).should.be.true;
@@ -58,9 +57,8 @@ describe('/', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(400);
 
         validator.validate(body, schema).should.be.true;
@@ -98,9 +96,8 @@ describe('/', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(500);
 
         validator.validate(body, schema).should.be.true;
@@ -142,9 +139,8 @@ describe('/', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(200);
 
         validator.validate(body, schema).should.be.true;
@@ -172,9 +168,8 @@ describe('/', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(400);
 
         validator.validate(body, schema).should.be.true;
@@ -202,9 +197,8 @@ describe('/', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         res.statusCode.should.equal(500);
 
         validator.validate(body, schema).should.be.true;

--- a/test/robust/compare/output2__Stub.js
+++ b/test/robust/compare/output2__Stub.js
@@ -23,7 +23,7 @@ describe('/', function() {
       };
       /*eslint-enable*/
       request({
-        url: 'https://api.uber.com/test/',
+        url: 'https://api.uber.com/',
         method: 'GET',
         headers: {
           'Content-Type': 'application/json'
@@ -33,6 +33,8 @@ describe('/', function() {
         if (error) {
           return done(error);
         }
+        res.statusCode.should.equal(200);
+
         validator.validate(body, schema).should.be.true;
         done();
       });
@@ -49,7 +51,7 @@ describe('/', function() {
       };
       /*eslint-enable*/
       request({
-        url: 'https://api.uber.com/test/',
+        url: 'https://api.uber.com/',
         method: 'GET',
         headers: {
           'Content-Type': 'application/json'
@@ -59,6 +61,8 @@ describe('/', function() {
         if (error) {
           return done(error);
         }
+        res.statusCode.should.equal(400);
+
         validator.validate(body, schema).should.be.true;
         done();
       });
@@ -87,7 +91,7 @@ describe('/', function() {
       };
       /*eslint-enable*/
       request({
-        url: 'https://api.uber.com/test/',
+        url: 'https://api.uber.com/',
         method: 'GET',
         headers: {
           'Content-Type': 'application/json'
@@ -97,6 +101,8 @@ describe('/', function() {
         if (error) {
           return done(error);
         }
+        res.statusCode.should.equal(500);
+
         validator.validate(body, schema).should.be.true;
         done();
       });
@@ -123,7 +129,7 @@ describe('/', function() {
       };
       /*eslint-enable*/
       request({
-        url: 'https://api.uber.com/test/',
+        url: 'https://api.uber.com/',
         qs: {
           longitude: 'DATA GOES HERE'
         },
@@ -139,6 +145,8 @@ describe('/', function() {
         if (error) {
           return done(error);
         }
+        res.statusCode.should.equal(200);
+
         validator.validate(body, schema).should.be.true;
         done();
       });
@@ -151,7 +159,7 @@ describe('/', function() {
       };
       /*eslint-enable*/
       request({
-        url: 'https://api.uber.com/test/',
+        url: 'https://api.uber.com/',
         qs: {
           longitude: 'DATA GOES HERE'
         },
@@ -167,6 +175,8 @@ describe('/', function() {
         if (error) {
           return done(error);
         }
+        res.statusCode.should.equal(400);
+
         validator.validate(body, schema).should.be.true;
         done();
       });
@@ -179,7 +189,7 @@ describe('/', function() {
       };
       /*eslint-enable*/
       request({
-        url: 'https://api.uber.com/test/',
+        url: 'https://api.uber.com/',
         qs: {
           longitude: 'DATA GOES HERE'
         },
@@ -195,6 +205,8 @@ describe('/', function() {
         if (error) {
           return done(error);
         }
+        res.statusCode.should.equal(500);
+
         validator.validate(body, schema).should.be.true;
         done();
       });

--- a/test/robust/compare/output3__Stub.js
+++ b/test/robust/compare/output3__Stub.js
@@ -27,9 +27,7 @@ describe('/', function() {
       .set('Accept', 'application/json')
       .expect(200)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         validator.validate(res.body, schema).should.be.true;
         done();
@@ -49,9 +47,7 @@ describe('/', function() {
       .set('Accept', 'application/json')
       .expect(400)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         validator.validate(res.body, schema).should.be.true;
         done();
@@ -83,9 +79,7 @@ describe('/', function() {
       .set('Accept', 'application/json')
       .expect(500)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         validator.validate(res.body, schema).should.be.true;
         done();
@@ -118,9 +112,7 @@ describe('/', function() {
       })
       .expect(200)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         validator.validate(res.body, schema).should.be.true;
         done();
@@ -140,9 +132,7 @@ describe('/', function() {
       })
       .expect(400)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         validator.validate(res.body, schema).should.be.true;
         done();
@@ -162,9 +152,7 @@ describe('/', function() {
       })
       .expect(500)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         validator.validate(res.body, schema).should.be.true;
         done();

--- a/test/robust/compare/output3__Stub.js
+++ b/test/robust/compare/output3__Stub.js
@@ -23,15 +23,15 @@ describe('/', function() {
         }
       };
       /*eslint-enable*/
-      api.get('/test/')
+      api.get('/')
       .set('Accept', 'application/json')
       .expect(200)
       .end(function(err, res) {
         if (err) {
           return done(err);
         }
-        validator.validate(res, schema).should.be.true;
-        res.should.have.property('name');
+
+        validator.validate(res.body, schema).should.be.true;
         done();
       });
     });
@@ -45,15 +45,15 @@ describe('/', function() {
         }
       };
       /*eslint-enable*/
-      api.get('/test/')
+      api.get('/')
       .set('Accept', 'application/json')
       .expect(400)
       .end(function(err, res) {
         if (err) {
           return done(err);
         }
-        validator.validate(res, schema).should.be.true;
-        res.should.have.property('name');
+
+        validator.validate(res.body, schema).should.be.true;
         done();
       });
     });
@@ -79,15 +79,15 @@ describe('/', function() {
         }
       };
       /*eslint-enable*/
-      api.get('/test/')
+      api.get('/')
       .set('Accept', 'application/json')
       .expect(500)
       .end(function(err, res) {
         if (err) {
           return done(err);
         }
-        validator.validate(res, schema).should.be.true;
-        res.should.have.property('name');
+
+        validator.validate(res.body, schema).should.be.true;
         done();
       });
     });
@@ -111,7 +111,7 @@ describe('/', function() {
         }
       };
       /*eslint-enable*/
-      api.post('/test/?longitude=DATA')
+      api.post('/?longitude=DATA')
       .set('Accept', 'application/json')
       .send({
         latitude: 'DATA GOES HERE'
@@ -121,8 +121,8 @@ describe('/', function() {
         if (err) {
           return done(err);
         }
-        validator.validate(res, schema).should.be.true;
 
+        validator.validate(res.body, schema).should.be.true;
         done();
       });
     });
@@ -133,7 +133,7 @@ describe('/', function() {
         "type": "number"
       };
       /*eslint-enable*/
-      api.post('/test/?longitude=DATA')
+      api.post('/?longitude=DATA')
       .set('Accept', 'application/json')
       .send({
         latitude: 'DATA GOES HERE'
@@ -143,8 +143,8 @@ describe('/', function() {
         if (err) {
           return done(err);
         }
-        validator.validate(res, schema).should.be.true;
 
+        validator.validate(res.body, schema).should.be.true;
         done();
       });
     });
@@ -155,7 +155,7 @@ describe('/', function() {
         "type": "string"
       };
       /*eslint-enable*/
-      api.post('/test/?longitude=DATA')
+      api.post('/?longitude=DATA')
       .set('Accept', 'application/json')
       .send({
         latitude: 'DATA GOES HERE'
@@ -165,8 +165,8 @@ describe('/', function() {
         if (err) {
           return done(err);
         }
-        validator.validate(res, schema).should.be.true;
 
+        validator.validate(res.body, schema).should.be.true;
         done();
       });
     });

--- a/test/robust/compare/output3_user_Stub.js
+++ b/test/robust/compare/output3_user_Stub.js
@@ -12,9 +12,7 @@ describe('/user', function() {
       .set('Accept', 'application/json')
       .expect(200)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         res.body.should.equal(null); // non-json response or no schema
         done();
@@ -25,9 +23,7 @@ describe('/user', function() {
       .set('Accept', 'application/json')
       .expect(400)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         res.body.should.equal(null); // non-json response or no schema
         done();
@@ -38,9 +34,7 @@ describe('/user', function() {
       .set('Accept', 'application/json')
       .expect(500)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         res.body.should.equal(null); // non-json response or no schema
         done();
@@ -57,9 +51,7 @@ describe('/user', function() {
       })
       .expect(200)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         res.body.should.equal(null); // non-json response or no schema
         done();
@@ -74,9 +66,7 @@ describe('/user', function() {
       })
       .expect(400)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         res.body.should.equal(null); // non-json response or no schema
         done();
@@ -91,9 +81,7 @@ describe('/user', function() {
       })
       .expect(500)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         res.body.should.equal(null); // non-json response or no schema
         done();

--- a/test/robust/compare/output3_user_Stub.js
+++ b/test/robust/compare/output3_user_Stub.js
@@ -8,41 +8,41 @@ var api = supertest('https://api.uber.com'); // supertest init;
 describe('/user', function() {
   describe('get', function() {
     it('should respond with 200 OK', function(done) {
-      api.get('/test/user')
+      api.get('/user')
       .set('Accept', 'application/json')
       .expect(200)
       .end(function(err, res) {
         if (err) {
           return done(err);
         }
-        res.should.equal(null);
-        res.should.have.property('name');
+
+        res.body.should.equal(null); // non-json response or no schema
         done();
       });
     });
     it('should respond with 400 NOT OK', function(done) {
-      api.get('/test/user')
+      api.get('/user')
       .set('Accept', 'application/json')
       .expect(400)
       .end(function(err, res) {
         if (err) {
           return done(err);
         }
-        res.should.equal(null);
-        res.should.have.property('name');
+
+        res.body.should.equal(null); // non-json response or no schema
         done();
       });
     });
     it('should respond with 500 SERVER ERROR', function(done) {
-      api.get('/test/user')
+      api.get('/user')
       .set('Accept', 'application/json')
       .expect(500)
       .end(function(err, res) {
         if (err) {
           return done(err);
         }
-        res.should.equal(null);
-        res.should.have.property('name');
+
+        res.body.should.equal(null); // non-json response or no schema
         done();
       });
     });
@@ -50,7 +50,7 @@ describe('/user', function() {
 
   describe('post', function() {
     it('should respond with 200 OK', function(done) {
-      api.post('/test/user?longitude=DATA')
+      api.post('/user?longitude=DATA')
       .set('Accept', 'application/json')
       .send({
         latitude: 'DATA GOES HERE'
@@ -60,13 +60,14 @@ describe('/user', function() {
         if (err) {
           return done(err);
         }
-        res.should.equal(null);
+
+        res.body.should.equal(null); // non-json response or no schema
         done();
       });
     });
 
     it('should respond with 400 NOT OK', function(done) {
-      api.post('/test/user?longitude=DATA')
+      api.post('/user?longitude=DATA')
       .set('Accept', 'application/json')
       .send({
         latitude: 'DATA GOES HERE'
@@ -76,13 +77,14 @@ describe('/user', function() {
         if (err) {
           return done(err);
         }
-        res.should.equal(null);
+
+        res.body.should.equal(null); // non-json response or no schema
         done();
       });
     });
 
     it('should respond with 500 SERVER ERROR', function(done) {
-      api.post('/test/user?longitude=DATA')
+      api.post('/user?longitude=DATA')
       .set('Accept', 'application/json')
       .send({
         latitude: 'DATA GOES HERE'
@@ -92,7 +94,8 @@ describe('/user', function() {
         if (err) {
           return done(err);
         }
-        res.should.equal(null);
+
+        res.body.should.equal(null); // non-json response or no schema
         done();
       });
     });

--- a/test/robust/compare/output4__Stub.js
+++ b/test/robust/compare/output4__Stub.js
@@ -27,9 +27,7 @@ describe('/', function() {
       .set('Accept', 'application/json')
       .expect(200)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         validator.validate(res.body, schema).should.be.true;
         done();
@@ -49,9 +47,7 @@ describe('/', function() {
       .set('Accept', 'application/json')
       .expect(400)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         validator.validate(res.body, schema).should.be.true;
         done();
@@ -83,9 +79,7 @@ describe('/', function() {
       .set('Accept', 'application/json')
       .expect(500)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         validator.validate(res.body, schema).should.be.true;
         done();
@@ -118,9 +112,7 @@ describe('/', function() {
       })
       .expect(200)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         validator.validate(res.body, schema).should.be.true;
         done();
@@ -140,9 +132,7 @@ describe('/', function() {
       })
       .expect(400)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         validator.validate(res.body, schema).should.be.true;
         done();
@@ -162,9 +152,7 @@ describe('/', function() {
       })
       .expect(500)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         validator.validate(res.body, schema).should.be.true;
         done();

--- a/test/robust/compare/output4__Stub.js
+++ b/test/robust/compare/output4__Stub.js
@@ -23,15 +23,15 @@ describe('/', function() {
         }
       };
       /*eslint-enable*/
-      api.get('/test/')
+      api.get('/')
       .set('Accept', 'application/json')
       .expect(200)
       .end(function(err, res) {
         if (err) {
           return done(err);
         }
-        validator.validate(res, schema).should.be.true;
-        res.should.have.property('name');
+
+        validator.validate(res.body, schema).should.be.true;
         done();
       });
     });
@@ -45,15 +45,15 @@ describe('/', function() {
         }
       };
       /*eslint-enable*/
-      api.get('/test/')
+      api.get('/')
       .set('Accept', 'application/json')
       .expect(400)
       .end(function(err, res) {
         if (err) {
           return done(err);
         }
-        validator.validate(res, schema).should.be.true;
-        res.should.have.property('name');
+
+        validator.validate(res.body, schema).should.be.true;
         done();
       });
     });
@@ -79,15 +79,15 @@ describe('/', function() {
         }
       };
       /*eslint-enable*/
-      api.get('/test/')
+      api.get('/')
       .set('Accept', 'application/json')
       .expect(500)
       .end(function(err, res) {
         if (err) {
           return done(err);
         }
-        validator.validate(res, schema).should.be.true;
-        res.should.have.property('name');
+
+        validator.validate(res.body, schema).should.be.true;
         done();
       });
     });
@@ -111,7 +111,7 @@ describe('/', function() {
         }
       };
       /*eslint-enable*/
-      api.post('/test/?longitude=DATA')
+      api.post('/?longitude=DATA')
       .set('Accept', 'application/json')
       .send({
         latitude: 'DATA GOES HERE'
@@ -121,8 +121,8 @@ describe('/', function() {
         if (err) {
           return done(err);
         }
-        validator.validate(res, schema).should.be.true;
 
+        validator.validate(res.body, schema).should.be.true;
         done();
       });
     });
@@ -133,7 +133,7 @@ describe('/', function() {
         "type": "number"
       };
       /*eslint-enable*/
-      api.post('/test/?longitude=DATA')
+      api.post('/?longitude=DATA')
       .set('Accept', 'application/json')
       .send({
         latitude: 'DATA GOES HERE'
@@ -143,8 +143,8 @@ describe('/', function() {
         if (err) {
           return done(err);
         }
-        validator.validate(res, schema).should.be.true;
 
+        validator.validate(res.body, schema).should.be.true;
         done();
       });
     });
@@ -155,7 +155,7 @@ describe('/', function() {
         "type": "string"
       };
       /*eslint-enable*/
-      api.post('/test/?longitude=DATA')
+      api.post('/?longitude=DATA')
       .set('Accept', 'application/json')
       .send({
         latitude: 'DATA GOES HERE'
@@ -165,8 +165,8 @@ describe('/', function() {
         if (err) {
           return done(err);
         }
-        validator.validate(res, schema).should.be.true;
 
+        validator.validate(res.body, schema).should.be.true;
         done();
       });
     });

--- a/test/robust/compare/output5__Stub.js
+++ b/test/robust/compare/output5__Stub.js
@@ -29,9 +29,8 @@ describe('/', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         assert.equal(res.statusCode, 200);
 
         assert.true(validator.validate(body, schema));
@@ -57,9 +56,8 @@ describe('/', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         assert.equal(res.statusCode, 400);
 
         assert.true(validator.validate(body, schema));
@@ -97,9 +95,8 @@ describe('/', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         assert.equal(res.statusCode, 500);
 
         assert.true(validator.validate(body, schema));
@@ -141,9 +138,8 @@ describe('/', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         assert.equal(res.statusCode, 200);
 
         assert.true(validator.validate(body, schema));
@@ -171,9 +167,8 @@ describe('/', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         assert.equal(res.statusCode, 400);
 
         assert.true(validator.validate(body, schema));
@@ -201,9 +196,8 @@ describe('/', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         assert.equal(res.statusCode, 500);
 
         assert.true(validator.validate(body, schema));

--- a/test/robust/compare/output5__Stub.js
+++ b/test/robust/compare/output5__Stub.js
@@ -22,7 +22,7 @@ describe('/', function() {
       };
       /*eslint-enable*/
       request({
-        url: 'https://api.uber.com/test/',
+        url: 'https://api.uber.com/',
         method: 'GET',
         headers: {
           'Content-Type': 'application/json'
@@ -32,6 +32,8 @@ describe('/', function() {
         if (error) {
           return done(error);
         }
+        assert.equal(res.statusCode, 200);
+
         assert.true(validator.validate(body, schema));
         done();
       });
@@ -48,7 +50,7 @@ describe('/', function() {
       };
       /*eslint-enable*/
       request({
-        url: 'https://api.uber.com/test/',
+        url: 'https://api.uber.com/',
         method: 'GET',
         headers: {
           'Content-Type': 'application/json'
@@ -58,6 +60,8 @@ describe('/', function() {
         if (error) {
           return done(error);
         }
+        assert.equal(res.statusCode, 400);
+
         assert.true(validator.validate(body, schema));
         done();
       });
@@ -86,7 +90,7 @@ describe('/', function() {
       };
       /*eslint-enable*/
       request({
-        url: 'https://api.uber.com/test/',
+        url: 'https://api.uber.com/',
         method: 'GET',
         headers: {
           'Content-Type': 'application/json'
@@ -96,6 +100,8 @@ describe('/', function() {
         if (error) {
           return done(error);
         }
+        assert.equal(res.statusCode, 500);
+
         assert.true(validator.validate(body, schema));
         done();
       });
@@ -122,7 +128,7 @@ describe('/', function() {
       };
       /*eslint-enable*/
       request({
-        url: 'https://api.uber.com/test/',
+        url: 'https://api.uber.com/',
         qs: {
           longitude: 'DATA GOES HERE'
         },
@@ -138,6 +144,8 @@ describe('/', function() {
         if (error) {
           return done(error);
         }
+        assert.equal(res.statusCode, 200);
+
         assert.true(validator.validate(body, schema));
         done();
       });
@@ -150,7 +158,7 @@ describe('/', function() {
       };
       /*eslint-enable*/
       request({
-        url: 'https://api.uber.com/test/',
+        url: 'https://api.uber.com/',
         qs: {
           longitude: 'DATA GOES HERE'
         },
@@ -166,6 +174,8 @@ describe('/', function() {
         if (error) {
           return done(error);
         }
+        assert.equal(res.statusCode, 400);
+
         assert.true(validator.validate(body, schema));
         done();
       });
@@ -178,7 +188,7 @@ describe('/', function() {
       };
       /*eslint-enable*/
       request({
-        url: 'https://api.uber.com/test/',
+        url: 'https://api.uber.com/',
         qs: {
           longitude: 'DATA GOES HERE'
         },
@@ -194,6 +204,8 @@ describe('/', function() {
         if (error) {
           return done(error);
         }
+        assert.equal(res.statusCode, 500);
+
         assert.true(validator.validate(body, schema));
         done();
       });

--- a/test/robust/compare/output5_user_Stub.js
+++ b/test/robust/compare/output5_user_Stub.js
@@ -7,7 +7,7 @@ describe('/user', function() {
   describe('get', function() {
     it('should respond with 200 OK', function(done) {
       request({
-        url: 'https://api.uber.com/test/user',
+        url: 'https://api.uber.com/user',
         method: 'GET',
         headers: {
           'Content-Type': 'application/json'
@@ -17,14 +17,16 @@ describe('/user', function() {
         if (error) {
           return done(error);
         }
-        assert.isNull(body);
+        assert.equal(res.statusCode, 200);
+
+        assert.isNull(body); // non-json response or no schema
         done();
       });
     });
 
     it('should respond with 400 NOT OK', function(done) {
       request({
-        url: 'https://api.uber.com/test/user',
+        url: 'https://api.uber.com/user',
         method: 'GET',
         headers: {
           'Content-Type': 'application/json'
@@ -34,14 +36,16 @@ describe('/user', function() {
         if (error) {
           return done(error);
         }
-        assert.isNull(body);
+        assert.equal(res.statusCode, 400);
+
+        assert.isNull(body); // non-json response or no schema
         done();
       });
     });
 
     it('should respond with 500 SERVER ERROR', function(done) {
       request({
-        url: 'https://api.uber.com/test/user',
+        url: 'https://api.uber.com/user',
         method: 'GET',
         headers: {
           'Content-Type': 'application/json'
@@ -51,7 +55,9 @@ describe('/user', function() {
         if (error) {
           return done(error);
         }
-        assert.isNull(body);
+        assert.equal(res.statusCode, 500);
+
+        assert.isNull(body); // non-json response or no schema
         done();
       });
     });
@@ -61,7 +67,7 @@ describe('/user', function() {
   describe('post', function() {
     it('should respond with 200 OK', function(done) {
       request({
-        url: 'https://api.uber.com/test/user',
+        url: 'https://api.uber.com/user',
         qs: {
           longitude: 'DATA GOES HERE'
         },
@@ -77,14 +83,16 @@ describe('/user', function() {
         if (error) {
           return done(error);
         }
-        assert.isNull(body);
+        assert.equal(res.statusCode, 200);
+
+        assert.isNull(body); // non-json response or no schema
         done();
       });
     });
 
     it('should respond with 400 NOT OK', function(done) {
       request({
-        url: 'https://api.uber.com/test/user',
+        url: 'https://api.uber.com/user',
         qs: {
           longitude: 'DATA GOES HERE'
         },
@@ -100,14 +108,16 @@ describe('/user', function() {
         if (error) {
           return done(error);
         }
-        assert.isNull(body);
+        assert.equal(res.statusCode, 400);
+
+        assert.isNull(body); // non-json response or no schema
         done();
       });
     });
 
     it('should respond with 500 SERVER ERROR', function(done) {
       request({
-        url: 'https://api.uber.com/test/user',
+        url: 'https://api.uber.com/user',
         qs: {
           longitude: 'DATA GOES HERE'
         },
@@ -123,7 +133,9 @@ describe('/user', function() {
         if (error) {
           return done(error);
         }
-        assert.isNull(body);
+        assert.equal(res.statusCode, 500);
+
+        assert.isNull(body); // non-json response or no schema
         done();
       });
     });

--- a/test/robust/compare/output5_user_Stub.js
+++ b/test/robust/compare/output5_user_Stub.js
@@ -14,9 +14,8 @@ describe('/user', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         assert.equal(res.statusCode, 200);
 
         assert.isNull(body); // non-json response or no schema
@@ -33,9 +32,8 @@ describe('/user', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         assert.equal(res.statusCode, 400);
 
         assert.isNull(body); // non-json response or no schema
@@ -52,9 +50,8 @@ describe('/user', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         assert.equal(res.statusCode, 500);
 
         assert.isNull(body); // non-json response or no schema
@@ -80,9 +77,8 @@ describe('/user', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         assert.equal(res.statusCode, 200);
 
         assert.isNull(body); // non-json response or no schema
@@ -105,9 +101,8 @@ describe('/user', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         assert.equal(res.statusCode, 400);
 
         assert.isNull(body); // non-json response or no schema
@@ -130,9 +125,8 @@ describe('/user', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         assert.equal(res.statusCode, 500);
 
         assert.isNull(body); // non-json response or no schema

--- a/test/robust/compare/output6__Stub.js
+++ b/test/robust/compare/output6__Stub.js
@@ -22,7 +22,7 @@ describe('/', function() {
       };
       /*eslint-enable*/
       request({
-        url: 'https://api.uber.com/test/',
+        url: 'https://api.uber.com/',
         method: 'GET',
         headers: {
           'Content-Type': 'application/json'
@@ -32,6 +32,8 @@ describe('/', function() {
         if (error) {
           return done(error);
         }
+        expect(res.statusCode).to.equal(200);
+
         expect(validator.validate(body, schema)).to.be.true;
         done();
       });
@@ -48,7 +50,7 @@ describe('/', function() {
       };
       /*eslint-enable*/
       request({
-        url: 'https://api.uber.com/test/',
+        url: 'https://api.uber.com/',
         method: 'GET',
         headers: {
           'Content-Type': 'application/json'
@@ -58,6 +60,8 @@ describe('/', function() {
         if (error) {
           return done(error);
         }
+        expect(res.statusCode).to.equal(400);
+
         expect(validator.validate(body, schema)).to.be.true;
         done();
       });
@@ -86,7 +90,7 @@ describe('/', function() {
       };
       /*eslint-enable*/
       request({
-        url: 'https://api.uber.com/test/',
+        url: 'https://api.uber.com/',
         method: 'GET',
         headers: {
           'Content-Type': 'application/json'
@@ -96,6 +100,8 @@ describe('/', function() {
         if (error) {
           return done(error);
         }
+        expect(res.statusCode).to.equal(500);
+
         expect(validator.validate(body, schema)).to.be.true;
         done();
       });
@@ -122,7 +128,7 @@ describe('/', function() {
       };
       /*eslint-enable*/
       request({
-        url: 'https://api.uber.com/test/',
+        url: 'https://api.uber.com/',
         qs: {
           longitude: 'DATA GOES HERE'
         },
@@ -138,6 +144,8 @@ describe('/', function() {
         if (error) {
           return done(error);
         }
+        expect(res.statusCode).to.equal(200);
+
         expect(validator.validate(body, schema)).to.be.true;
         done();
       });
@@ -150,7 +158,7 @@ describe('/', function() {
       };
       /*eslint-enable*/
       request({
-        url: 'https://api.uber.com/test/',
+        url: 'https://api.uber.com/',
         qs: {
           longitude: 'DATA GOES HERE'
         },
@@ -166,6 +174,8 @@ describe('/', function() {
         if (error) {
           return done(error);
         }
+        expect(res.statusCode).to.equal(400);
+
         expect(validator.validate(body, schema)).to.be.true;
         done();
       });
@@ -178,7 +188,7 @@ describe('/', function() {
       };
       /*eslint-enable*/
       request({
-        url: 'https://api.uber.com/test/',
+        url: 'https://api.uber.com/',
         qs: {
           longitude: 'DATA GOES HERE'
         },
@@ -194,6 +204,8 @@ describe('/', function() {
         if (error) {
           return done(error);
         }
+        expect(res.statusCode).to.equal(500);
+
         expect(validator.validate(body, schema)).to.be.true;
         done();
       });

--- a/test/robust/compare/output6__Stub.js
+++ b/test/robust/compare/output6__Stub.js
@@ -29,9 +29,8 @@ describe('/', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         expect(res.statusCode).to.equal(200);
 
         expect(validator.validate(body, schema)).to.be.true;
@@ -57,9 +56,8 @@ describe('/', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         expect(res.statusCode).to.equal(400);
 
         expect(validator.validate(body, schema)).to.be.true;
@@ -97,9 +95,8 @@ describe('/', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         expect(res.statusCode).to.equal(500);
 
         expect(validator.validate(body, schema)).to.be.true;
@@ -141,9 +138,8 @@ describe('/', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         expect(res.statusCode).to.equal(200);
 
         expect(validator.validate(body, schema)).to.be.true;
@@ -171,9 +167,8 @@ describe('/', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         expect(res.statusCode).to.equal(400);
 
         expect(validator.validate(body, schema)).to.be.true;
@@ -201,9 +196,8 @@ describe('/', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         expect(res.statusCode).to.equal(500);
 
         expect(validator.validate(body, schema)).to.be.true;

--- a/test/robust/compare/output6_user_Stub.js
+++ b/test/robust/compare/output6_user_Stub.js
@@ -7,7 +7,7 @@ describe('/user', function() {
   describe('get', function() {
     it('should respond with 200 OK', function(done) {
       request({
-        url: 'https://api.uber.com/test/user',
+        url: 'https://api.uber.com/user',
         method: 'GET',
         headers: {
           'Content-Type': 'application/json'
@@ -17,14 +17,16 @@ describe('/user', function() {
         if (error) {
           return done(error);
         }
-        expect(body).to.equal(null);
+        expect(res.statusCode).to.equal(200);
+
+        expect(body).to.equal(null); // non-json response or no schema
         done();
       });
     });
 
     it('should respond with 400 NOT OK', function(done) {
       request({
-        url: 'https://api.uber.com/test/user',
+        url: 'https://api.uber.com/user',
         method: 'GET',
         headers: {
           'Content-Type': 'application/json'
@@ -34,14 +36,16 @@ describe('/user', function() {
         if (error) {
           return done(error);
         }
-        expect(body).to.equal(null);
+        expect(res.statusCode).to.equal(400);
+
+        expect(body).to.equal(null); // non-json response or no schema
         done();
       });
     });
 
     it('should respond with 500 SERVER ERROR', function(done) {
       request({
-        url: 'https://api.uber.com/test/user',
+        url: 'https://api.uber.com/user',
         method: 'GET',
         headers: {
           'Content-Type': 'application/json'
@@ -51,7 +55,9 @@ describe('/user', function() {
         if (error) {
           return done(error);
         }
-        expect(body).to.equal(null);
+        expect(res.statusCode).to.equal(500);
+
+        expect(body).to.equal(null); // non-json response or no schema
         done();
       });
     });
@@ -61,7 +67,7 @@ describe('/user', function() {
   describe('post', function() {
     it('should respond with 200 OK', function(done) {
       request({
-        url: 'https://api.uber.com/test/user',
+        url: 'https://api.uber.com/user',
         qs: {
           longitude: 'DATA GOES HERE'
         },
@@ -77,14 +83,16 @@ describe('/user', function() {
         if (error) {
           return done(error);
         }
-        expect(body).to.equal(null);
+        expect(res.statusCode).to.equal(200);
+
+        expect(body).to.equal(null); // non-json response or no schema
         done();
       });
     });
 
     it('should respond with 400 NOT OK', function(done) {
       request({
-        url: 'https://api.uber.com/test/user',
+        url: 'https://api.uber.com/user',
         qs: {
           longitude: 'DATA GOES HERE'
         },
@@ -100,14 +108,16 @@ describe('/user', function() {
         if (error) {
           return done(error);
         }
-        expect(body).to.equal(null);
+        expect(res.statusCode).to.equal(400);
+
+        expect(body).to.equal(null); // non-json response or no schema
         done();
       });
     });
 
     it('should respond with 500 SERVER ERROR', function(done) {
       request({
-        url: 'https://api.uber.com/test/user',
+        url: 'https://api.uber.com/user',
         qs: {
           longitude: 'DATA GOES HERE'
         },
@@ -123,7 +133,9 @@ describe('/user', function() {
         if (error) {
           return done(error);
         }
-        expect(body).to.equal(null);
+        expect(res.statusCode).to.equal(500);
+
+        expect(body).to.equal(null); // non-json response or no schema
         done();
       });
     });

--- a/test/robust/compare/output6_user_Stub.js
+++ b/test/robust/compare/output6_user_Stub.js
@@ -14,9 +14,8 @@ describe('/user', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         expect(res.statusCode).to.equal(200);
 
         expect(body).to.equal(null); // non-json response or no schema
@@ -33,9 +32,8 @@ describe('/user', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         expect(res.statusCode).to.equal(400);
 
         expect(body).to.equal(null); // non-json response or no schema
@@ -52,9 +50,8 @@ describe('/user', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         expect(res.statusCode).to.equal(500);
 
         expect(body).to.equal(null); // non-json response or no schema
@@ -80,9 +77,8 @@ describe('/user', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         expect(res.statusCode).to.equal(200);
 
         expect(body).to.equal(null); // non-json response or no schema
@@ -105,9 +101,8 @@ describe('/user', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         expect(res.statusCode).to.equal(400);
 
         expect(body).to.equal(null); // non-json response or no schema
@@ -130,9 +125,8 @@ describe('/user', function() {
         }
       },
       function(error, res, body) {
-        if (error) {
-          return done(error);
-        }
+        if (error) return done(error);
+
         expect(res.statusCode).to.equal(500);
 
         expect(body).to.equal(null); // non-json response or no schema

--- a/test/robust/compare/output7__Stub.js
+++ b/test/robust/compare/output7__Stub.js
@@ -26,9 +26,7 @@ describe('/', function() {
       .set('Accept', 'application/json')
       .expect(200)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         assert.true(validator.validate(res.body, schema));
         done();
@@ -48,9 +46,7 @@ describe('/', function() {
       .set('Accept', 'application/json')
       .expect(400)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         assert.true(validator.validate(res.body, schema));
         done();
@@ -82,9 +78,7 @@ describe('/', function() {
       .set('Accept', 'application/json')
       .expect(500)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         assert.true(validator.validate(res.body, schema));
         done();
@@ -117,9 +111,7 @@ describe('/', function() {
       })
       .expect(200)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         assert.true(validator.validate(res.body, schema));
         done();
@@ -139,9 +131,7 @@ describe('/', function() {
       })
       .expect(400)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         assert.true(validator.validate(res.body, schema));
         done();
@@ -161,9 +151,7 @@ describe('/', function() {
       })
       .expect(500)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         assert.true(validator.validate(res.body, schema));
         done();

--- a/test/robust/compare/output7__Stub.js
+++ b/test/robust/compare/output7__Stub.js
@@ -22,15 +22,15 @@ describe('/', function() {
         }
       };
       /*eslint-enable*/
-      api.get('/test/')
+      api.get('/')
       .set('Accept', 'application/json')
       .expect(200)
       .end(function(err, res) {
         if (err) {
           return done(err);
         }
-        assert.true(validator.validate(res, schema));
-        assert.property(res, 'name');
+
+        assert.true(validator.validate(res.body, schema));
         done();
       });
     });
@@ -44,15 +44,15 @@ describe('/', function() {
         }
       };
       /*eslint-enable*/
-      api.get('/test/')
+      api.get('/')
       .set('Accept', 'application/json')
       .expect(400)
       .end(function(err, res) {
         if (err) {
           return done(err);
         }
-        assert.true(validator.validate(res, schema));
-        assert.property(res, 'name');
+
+        assert.true(validator.validate(res.body, schema));
         done();
       });
     });
@@ -78,15 +78,15 @@ describe('/', function() {
         }
       };
       /*eslint-enable*/
-      api.get('/test/')
+      api.get('/')
       .set('Accept', 'application/json')
       .expect(500)
       .end(function(err, res) {
         if (err) {
           return done(err);
         }
-        assert.true(validator.validate(res, schema));
-        assert.property(res, 'name');
+
+        assert.true(validator.validate(res.body, schema));
         done();
       });
     });
@@ -110,7 +110,7 @@ describe('/', function() {
         }
       };
       /*eslint-enable*/
-      api.post('/test/?longitude=DATA')
+      api.post('/?longitude=DATA')
       .set('Accept', 'application/json')
       .send({
         latitude: 'DATA GOES HERE'
@@ -120,7 +120,8 @@ describe('/', function() {
         if (err) {
           return done(err);
         }
-        assert.true(validator.validate(res, schema));
+
+        assert.true(validator.validate(res.body, schema));
         done();
       });
     });
@@ -131,7 +132,7 @@ describe('/', function() {
         "type": "number"
       };
       /*eslint-enable*/
-      api.post('/test/?longitude=DATA')
+      api.post('/?longitude=DATA')
       .set('Accept', 'application/json')
       .send({
         latitude: 'DATA GOES HERE'
@@ -141,7 +142,8 @@ describe('/', function() {
         if (err) {
           return done(err);
         }
-        assert.true(validator.validate(res, schema));
+
+        assert.true(validator.validate(res.body, schema));
         done();
       });
     });
@@ -152,7 +154,7 @@ describe('/', function() {
         "type": "string"
       };
       /*eslint-enable*/
-      api.post('/test/?longitude=DATA')
+      api.post('/?longitude=DATA')
       .set('Accept', 'application/json')
       .send({
         latitude: 'DATA GOES HERE'
@@ -162,7 +164,8 @@ describe('/', function() {
         if (err) {
           return done(err);
         }
-        assert.true(validator.validate(res, schema));
+
+        assert.true(validator.validate(res.body, schema));
         done();
       });
     });

--- a/test/robust/compare/output7_user_Stub.js
+++ b/test/robust/compare/output7_user_Stub.js
@@ -7,41 +7,41 @@ var api = supertest('https://api.uber.com'); // supertest init;
 describe('/user', function() {
   describe('get', function() {
     it('should respond with 200 OK', function(done) {
-      api.get('/test/user')
+      api.get('/user')
       .set('Accept', 'application/json')
       .expect(200)
       .end(function(err, res) {
         if (err) {
           return done(err);
         }
-        assert.isNull(res);
-        assert.property(res, 'name');
+
+        assert.isNull(res.body); // non-json response or no schema
         done();
       });
     });
     it('should respond with 400 NOT OK', function(done) {
-      api.get('/test/user')
+      api.get('/user')
       .set('Accept', 'application/json')
       .expect(400)
       .end(function(err, res) {
         if (err) {
           return done(err);
         }
-        assert.isNull(res);
-        assert.property(res, 'name');
+
+        assert.isNull(res.body); // non-json response or no schema
         done();
       });
     });
     it('should respond with 500 SERVER ERROR', function(done) {
-      api.get('/test/user')
+      api.get('/user')
       .set('Accept', 'application/json')
       .expect(500)
       .end(function(err, res) {
         if (err) {
           return done(err);
         }
-        assert.isNull(res);
-        assert.property(res, 'name');
+
+        assert.isNull(res.body); // non-json response or no schema
         done();
       });
     });
@@ -49,7 +49,7 @@ describe('/user', function() {
 
   describe('post', function() {
     it('should respond with 200 OK', function(done) {
-      api.post('/test/user?longitude=DATA')
+      api.post('/user?longitude=DATA')
       .set('Accept', 'application/json')
       .send({
         latitude: 'DATA GOES HERE'
@@ -59,13 +59,14 @@ describe('/user', function() {
         if (err) {
           return done(err);
         }
-        assert.isNull(res);
+
+        assert.isNull(res.body); // non-json response or no schema
         done();
       });
     });
 
     it('should respond with 400 NOT OK', function(done) {
-      api.post('/test/user?longitude=DATA')
+      api.post('/user?longitude=DATA')
       .set('Accept', 'application/json')
       .send({
         latitude: 'DATA GOES HERE'
@@ -75,13 +76,14 @@ describe('/user', function() {
         if (err) {
           return done(err);
         }
-        assert.isNull(res);
+
+        assert.isNull(res.body); // non-json response or no schema
         done();
       });
     });
 
     it('should respond with 500 SERVER ERROR', function(done) {
-      api.post('/test/user?longitude=DATA')
+      api.post('/user?longitude=DATA')
       .set('Accept', 'application/json')
       .send({
         latitude: 'DATA GOES HERE'
@@ -91,7 +93,8 @@ describe('/user', function() {
         if (err) {
           return done(err);
         }
-        assert.isNull(res);
+
+        assert.isNull(res.body); // non-json response or no schema
         done();
       });
     });

--- a/test/robust/compare/output7_user_Stub.js
+++ b/test/robust/compare/output7_user_Stub.js
@@ -11,9 +11,7 @@ describe('/user', function() {
       .set('Accept', 'application/json')
       .expect(200)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         assert.isNull(res.body); // non-json response or no schema
         done();
@@ -24,9 +22,7 @@ describe('/user', function() {
       .set('Accept', 'application/json')
       .expect(400)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         assert.isNull(res.body); // non-json response or no schema
         done();
@@ -37,9 +33,7 @@ describe('/user', function() {
       .set('Accept', 'application/json')
       .expect(500)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         assert.isNull(res.body); // non-json response or no schema
         done();
@@ -56,9 +50,7 @@ describe('/user', function() {
       })
       .expect(200)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         assert.isNull(res.body); // non-json response or no schema
         done();
@@ -73,9 +65,7 @@ describe('/user', function() {
       })
       .expect(400)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         assert.isNull(res.body); // non-json response or no schema
         done();
@@ -90,9 +80,7 @@ describe('/user', function() {
       })
       .expect(500)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         assert.isNull(res.body); // non-json response or no schema
         done();

--- a/test/robust/compare/output8__Stub.js
+++ b/test/robust/compare/output8__Stub.js
@@ -26,9 +26,7 @@ describe('/', function() {
       .set('Accept', 'application/json')
       .expect(200)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         expect(validator.validate(res.body, schema)).to.be.true;
         done();
@@ -48,9 +46,7 @@ describe('/', function() {
       .set('Accept', 'application/json')
       .expect(400)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         expect(validator.validate(res.body, schema)).to.be.true;
         done();
@@ -82,9 +78,7 @@ describe('/', function() {
       .set('Accept', 'application/json')
       .expect(500)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         expect(validator.validate(res.body, schema)).to.be.true;
         done();
@@ -117,9 +111,7 @@ describe('/', function() {
       })
       .expect(200)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         expect(validator.validate(res.body, schema)).to.be.true;
         done();
@@ -139,9 +131,7 @@ describe('/', function() {
       })
       .expect(400)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         expect(validator.validate(res.body, schema)).to.be.true;
         done();
@@ -161,9 +151,7 @@ describe('/', function() {
       })
       .expect(500)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         expect(validator.validate(res.body, schema)).to.be.true;
         done();

--- a/test/robust/compare/output8__Stub.js
+++ b/test/robust/compare/output8__Stub.js
@@ -22,15 +22,15 @@ describe('/', function() {
         }
       };
       /*eslint-enable*/
-      api.get('/test/')
+      api.get('/')
       .set('Accept', 'application/json')
       .expect(200)
       .end(function(err, res) {
         if (err) {
           return done(err);
         }
-        expect(validator.validate(res, schema)).to.be.true;
-        expect(res).to.have.property('name');
+
+        expect(validator.validate(res.body, schema)).to.be.true;
         done();
       });
     });
@@ -44,15 +44,15 @@ describe('/', function() {
         }
       };
       /*eslint-enable*/
-      api.get('/test/')
+      api.get('/')
       .set('Accept', 'application/json')
       .expect(400)
       .end(function(err, res) {
         if (err) {
           return done(err);
         }
-        expect(validator.validate(res, schema)).to.be.true;
-        expect(res).to.have.property('name');
+
+        expect(validator.validate(res.body, schema)).to.be.true;
         done();
       });
     });
@@ -78,15 +78,15 @@ describe('/', function() {
         }
       };
       /*eslint-enable*/
-      api.get('/test/')
+      api.get('/')
       .set('Accept', 'application/json')
       .expect(500)
       .end(function(err, res) {
         if (err) {
           return done(err);
         }
-        expect(validator.validate(res, schema)).to.be.true;
-        expect(res).to.have.property('name');
+
+        expect(validator.validate(res.body, schema)).to.be.true;
         done();
       });
     });
@@ -110,7 +110,7 @@ describe('/', function() {
         }
       };
       /*eslint-enable*/
-      api.post('/test/?longitude=DATA')
+      api.post('/?longitude=DATA')
       .set('Accept', 'application/json')
       .send({
         latitude: 'DATA GOES HERE'
@@ -120,8 +120,8 @@ describe('/', function() {
         if (err) {
           return done(err);
         }
-        expect(validator.validate(res, schema)).to.be.true;
 
+        expect(validator.validate(res.body, schema)).to.be.true;
         done();
       });
     });
@@ -132,7 +132,7 @@ describe('/', function() {
         "type": "number"
       };
       /*eslint-enable*/
-      api.post('/test/?longitude=DATA')
+      api.post('/?longitude=DATA')
       .set('Accept', 'application/json')
       .send({
         latitude: 'DATA GOES HERE'
@@ -142,8 +142,8 @@ describe('/', function() {
         if (err) {
           return done(err);
         }
-        expect(validator.validate(res, schema)).to.be.true;
 
+        expect(validator.validate(res.body, schema)).to.be.true;
         done();
       });
     });
@@ -154,7 +154,7 @@ describe('/', function() {
         "type": "string"
       };
       /*eslint-enable*/
-      api.post('/test/?longitude=DATA')
+      api.post('/?longitude=DATA')
       .set('Accept', 'application/json')
       .send({
         latitude: 'DATA GOES HERE'
@@ -164,8 +164,8 @@ describe('/', function() {
         if (err) {
           return done(err);
         }
-        expect(validator.validate(res, schema)).to.be.true;
 
+        expect(validator.validate(res.body, schema)).to.be.true;
         done();
       });
     });

--- a/test/robust/compare/output8_user_Stub.js
+++ b/test/robust/compare/output8_user_Stub.js
@@ -11,9 +11,7 @@ describe('/user', function() {
       .set('Accept', 'application/json')
       .expect(200)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         expect(res.body).to.equal(null); // non-json response or no schema
         done();
@@ -24,9 +22,7 @@ describe('/user', function() {
       .set('Accept', 'application/json')
       .expect(400)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         expect(res.body).to.equal(null); // non-json response or no schema
         done();
@@ -37,9 +33,7 @@ describe('/user', function() {
       .set('Accept', 'application/json')
       .expect(500)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         expect(res.body).to.equal(null); // non-json response or no schema
         done();
@@ -56,9 +50,7 @@ describe('/user', function() {
       })
       .expect(200)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         expect(res.body).to.equal(null); // non-json response or no schema
         done();
@@ -73,9 +65,7 @@ describe('/user', function() {
       })
       .expect(400)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         expect(res.body).to.equal(null); // non-json response or no schema
         done();
@@ -90,9 +80,7 @@ describe('/user', function() {
       })
       .expect(500)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         expect(res.body).to.equal(null); // non-json response or no schema
         done();

--- a/test/robust/compare/output8_user_Stub.js
+++ b/test/robust/compare/output8_user_Stub.js
@@ -7,41 +7,41 @@ var api = supertest('https://api.uber.com'); // supertest init;
 describe('/user', function() {
   describe('get', function() {
     it('should respond with 200 OK', function(done) {
-      api.get('/test/user')
+      api.get('/user')
       .set('Accept', 'application/json')
       .expect(200)
       .end(function(err, res) {
         if (err) {
           return done(err);
         }
-        expect(res).to.equal(null);
-        expect(res).to.have.property('name');
+
+        expect(res.body).to.equal(null); // non-json response or no schema
         done();
       });
     });
     it('should respond with 400 NOT OK', function(done) {
-      api.get('/test/user')
+      api.get('/user')
       .set('Accept', 'application/json')
       .expect(400)
       .end(function(err, res) {
         if (err) {
           return done(err);
         }
-        expect(res).to.equal(null);
-        expect(res).to.have.property('name');
+
+        expect(res.body).to.equal(null); // non-json response or no schema
         done();
       });
     });
     it('should respond with 500 SERVER ERROR', function(done) {
-      api.get('/test/user')
+      api.get('/user')
       .set('Accept', 'application/json')
       .expect(500)
       .end(function(err, res) {
         if (err) {
           return done(err);
         }
-        expect(res).to.equal(null);
-        expect(res).to.have.property('name');
+
+        expect(res.body).to.equal(null); // non-json response or no schema
         done();
       });
     });
@@ -49,7 +49,7 @@ describe('/user', function() {
 
   describe('post', function() {
     it('should respond with 200 OK', function(done) {
-      api.post('/test/user?longitude=DATA')
+      api.post('/user?longitude=DATA')
       .set('Accept', 'application/json')
       .send({
         latitude: 'DATA GOES HERE'
@@ -59,13 +59,14 @@ describe('/user', function() {
         if (err) {
           return done(err);
         }
-        expect(res).to.equal(null);
+
+        expect(res.body).to.equal(null); // non-json response or no schema
         done();
       });
     });
 
     it('should respond with 400 NOT OK', function(done) {
-      api.post('/test/user?longitude=DATA')
+      api.post('/user?longitude=DATA')
       .set('Accept', 'application/json')
       .send({
         latitude: 'DATA GOES HERE'
@@ -75,13 +76,14 @@ describe('/user', function() {
         if (err) {
           return done(err);
         }
-        expect(res).to.equal(null);
+
+        expect(res.body).to.equal(null); // non-json response or no schema
         done();
       });
     });
 
     it('should respond with 500 SERVER ERROR', function(done) {
-      api.post('/test/user?longitude=DATA')
+      api.post('/user?longitude=DATA')
       .set('Accept', 'application/json')
       .send({
         latitude: 'DATA GOES HERE'
@@ -91,7 +93,8 @@ describe('/user', function() {
         if (err) {
           return done(err);
         }
-        expect(res).to.equal(null);
+
+        expect(res.body).to.equal(null); // non-json response or no schema
         done();
       });
     });

--- a/test/robust/compare/output9__Stub.js
+++ b/test/robust/compare/output9__Stub.js
@@ -1,0 +1,167 @@
+'use strict';
+var chai = require('chai');
+var ZSchema = require('z-schema');
+var validator = new ZSchema({});
+
+chai.should();
+var supertest = require('supertest');
+var api = supertest('https://api.uber.com'); // supertest init;
+
+describe('/', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "username": {
+            "type": "string"
+          }
+        }
+      };
+      /*eslint-enable*/
+      api.get('/')
+      .set('Accept', 'application/xml')
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        validator.validate(res.body, schema).should.be.true;
+        done();
+      });
+    });
+    it('should respond with 400 NOT OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "properties": {
+          "meta": "string",
+          "data": "number"
+        }
+      };
+      /*eslint-enable*/
+      api.get('/')
+      .set('Accept', 'application/xml')
+      .expect(400)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        validator.validate(res.body, schema).should.be.true;
+        done();
+      });
+    });
+    it('should respond with 500 SERVER ERROR', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "properties": {
+          "meta": "string",
+          "data": "number",
+          "UserObj": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "integer"
+                },
+                "username": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+      api.get('/')
+      .set('Accept', 'application/xml')
+      .expect(500)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        validator.validate(res.body, schema).should.be.true;
+        done();
+      });
+    });
+  });
+
+  describe('post', function() {
+    it('should respond with 200 OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "integer"
+            },
+            "username": {
+              "type": "string"
+            }
+          }
+        }
+      };
+      /*eslint-enable*/
+      api.post('/?longitude=DATA')
+      .set('Accept', 'application/xml')
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        validator.validate(res.body, schema).should.be.true;
+        done();
+      });
+    });
+
+    it('should respond with 400 NOT OK', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "number"
+      };
+      /*eslint-enable*/
+      api.post('/?longitude=DATA')
+      .set('Accept', 'application/xml')
+      .expect(400)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        validator.validate(res.body, schema).should.be.true;
+        done();
+      });
+    });
+
+    it('should respond with 500 SERVER ERROR', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "string"
+      };
+      /*eslint-enable*/
+      api.post('/?longitude=DATA')
+      .set('Accept', 'application/xml')
+      .expect(500)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        validator.validate(res.body, schema).should.be.true;
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/robust/compare/output9__Stub.js
+++ b/test/robust/compare/output9__Stub.js
@@ -27,9 +27,7 @@ describe('/', function() {
       .set('Accept', 'application/xml')
       .expect(200)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         validator.validate(res.body, schema).should.be.true;
         done();
@@ -49,9 +47,7 @@ describe('/', function() {
       .set('Accept', 'application/xml')
       .expect(400)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         validator.validate(res.body, schema).should.be.true;
         done();
@@ -83,9 +79,7 @@ describe('/', function() {
       .set('Accept', 'application/xml')
       .expect(500)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         validator.validate(res.body, schema).should.be.true;
         done();
@@ -115,9 +109,7 @@ describe('/', function() {
       .set('Accept', 'application/xml')
       .expect(200)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         validator.validate(res.body, schema).should.be.true;
         done();
@@ -134,9 +126,7 @@ describe('/', function() {
       .set('Accept', 'application/xml')
       .expect(400)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         validator.validate(res.body, schema).should.be.true;
         done();
@@ -153,9 +143,7 @@ describe('/', function() {
       .set('Accept', 'application/xml')
       .expect(500)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         validator.validate(res.body, schema).should.be.true;
         done();

--- a/test/robust/compare/output9_user_Stub.js
+++ b/test/robust/compare/output9_user_Stub.js
@@ -12,9 +12,7 @@ describe('/user', function() {
       .set('Accept', 'application/xml')
       .expect(200)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         res.body.should.equal(null); // non-json response or no schema
         done();
@@ -25,9 +23,7 @@ describe('/user', function() {
       .set('Accept', 'application/xml')
       .expect(400)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         res.body.should.equal(null); // non-json response or no schema
         done();
@@ -38,9 +34,7 @@ describe('/user', function() {
       .set('Accept', 'application/xml')
       .expect(500)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         res.body.should.equal(null); // non-json response or no schema
         done();
@@ -54,9 +48,7 @@ describe('/user', function() {
       .set('Accept', 'application/xml')
       .expect(200)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         res.body.should.equal(null); // non-json response or no schema
         done();
@@ -68,9 +60,7 @@ describe('/user', function() {
       .set('Accept', 'application/xml')
       .expect(400)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         res.body.should.equal(null); // non-json response or no schema
         done();
@@ -82,9 +72,7 @@ describe('/user', function() {
       .set('Accept', 'application/xml')
       .expect(500)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         res.body.should.equal(null); // non-json response or no schema
         done();

--- a/test/robust/compare/output9_user_Stub.js
+++ b/test/robust/compare/output9_user_Stub.js
@@ -1,0 +1,96 @@
+'use strict';
+var chai = require('chai');
+
+chai.should();
+var supertest = require('supertest');
+var api = supertest('https://api.uber.com'); // supertest init;
+
+describe('/user', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      api.get('/user')
+      .set('Accept', 'application/xml')
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        res.body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+    it('should respond with 400 NOT OK', function(done) {
+      api.get('/user')
+      .set('Accept', 'application/xml')
+      .expect(400)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        res.body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+    it('should respond with 500 SERVER ERROR', function(done) {
+      api.get('/user')
+      .set('Accept', 'application/xml')
+      .expect(500)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        res.body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+  });
+
+  describe('post', function() {
+    it('should respond with 200 OK', function(done) {
+      api.post('/user?longitude=DATA')
+      .set('Accept', 'application/xml')
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        res.body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 400 NOT OK', function(done) {
+      api.post('/user?longitude=DATA')
+      .set('Accept', 'application/xml')
+      .expect(400)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        res.body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 500 SERVER ERROR', function(done) {
+      api.post('/user?longitude=DATA')
+      .set('Accept', 'application/xml')
+      .expect(500)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        res.body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/robust/swagger.json
+++ b/test/robust/swagger.json
@@ -8,7 +8,6 @@
     "schemes": [
         "https"
     ],
-    "basePath":"/test",
     "paths": {
         "/": {
             "get": {

--- a/test/robust/test.js
+++ b/test/robust/test.js
@@ -180,151 +180,400 @@ describe('robust swagger', function() {
         }
       });
     });
-  });
 
-  describe('supertest-option', function() {
-    describe('pathName-option', function() {
+    describe('consumes', function() {
+      swagger.consumes = ['application/xml'];
 
-      var output3 = testGen(swagger, {
+      var output18 = testGen(swagger, {
         assertionFormat: 'should',
         pathName: [],
-        testModule: 'supertest'
+        testModule: 'request'
       });
 
-      var paths3 = [];
+      var paths18 = [];
       var ndx;
 
-      for (ndx in output3) {
-        if (output3) {
-          paths3.push(join(__dirname, '/compare/output3' + output3[ndx].name));
+      for (ndx in output18) {
+        if (paths18 !== undefined) {
+          paths18.push(join(__dirname, '/compare/output18' +
+            output18[ndx].name));
         }
       }
 
-      it('should create all paths w/empty pathName flag w/should', function() {
+      it('should generate all paths with \'xml\' comsumes', function() {
 
-        assert.isArray(output3);
-        assert.lengthOf(output3, 2);
+        assert.isArray(output18);
+        assert.lengthOf(output18, 2);
 
         var generatedCode;
 
-        for (ndx in paths3) {
-          if (paths3 !== undefined) {
-            generatedCode = read(paths3[ndx], 'utf8');
-            assert.equal(output3[ndx].test, generatedCode);
+        for (ndx in paths18) {
+          if (paths18 !== undefined) {
+            generatedCode = read(paths18[ndx], 'utf8');
+            assert.equal(output18[ndx].test, generatedCode);
           }
         }
 
-        for (ndx in output3) {
-          if (output3 !== undefined) {
-            assert.lengthOf(linter.verify(output3[ndx].test, rules), 0);
+        for (ndx in output18) {
+          if (output18 !== undefined) {
+            assert.lengthOf(linter.verify(output18[ndx].test, rules), 0);
           }
         }
       });
 
-      var output4 = testGen(swagger, {
+      swagger.consumes.push('application/json');
+
+      var output17 = testGen(swagger, {
         assertionFormat: 'should',
-        pathName: ['/'],
-        testModule: 'supertest'
+        pathName: [],
+        testModule: 'request'
       });
 
-      var paths4 = [];
+      var paths17 = [];
 
-      for (ndx in output4) {
-        if (output4 !== undefined) {
-          paths4.push(join(__dirname, '/compare/output4' + output4[ndx].name));
+      for (ndx in output17) {
+        if (output17[ndx] !== undefined) {
+          paths17.push(join(__dirname, '/compare/output17'
+            + output17[ndx].name));
         }
       }
 
-      it('should create specified paths in pathName flag w/should', function() {
+      it('should generate all paths w/\'xml\' & \'json\' comsumes', function() {
 
-        assert.isArray(output4);
-        assert.lengthOf(output4, 1);
+        assert.isArray(output17);
+        assert.lengthOf(output17, 2);
 
         var generatedCode;
 
-        for (ndx in paths4) {
-          if (paths4 !== undefined) {
-            generatedCode = read(paths4[ndx], 'utf8');
-            assert.equal(output4[ndx].test, generatedCode);
+        for (ndx in paths17) {
+          if (paths17[ndx] !== undefined) {
+            generatedCode = read(paths17[ndx], 'utf8');
+            assert.equal(output17[ndx].test, generatedCode);
           }
         }
 
-        for (ndx in output4) {
-          if (output4 !== undefined) {
-            assert.lengthOf(linter.verify(output4[ndx].test, rules), 0);
+        for (ndx in output17) {
+          if (output17 !== undefined) {
+            assert.lengthOf(linter.verify(output17[ndx].test, rules), 0);
           }
         }
       });
     });
 
-    describe('assertionFormat-option', function() {
-      var output7 = testGen(swagger, {
-        assertionFormat: 'assert',
+    describe('produces', function() {
+      swagger.produces = ['application/xml'];
+
+      var output16 = testGen(swagger, {
+        assertionFormat: 'should',
         pathName: [],
-        testModule: 'supertest'
+        testModule: 'request'
       });
 
-      var paths7 = [];
+      var paths16 = [];
       var ndx;
 
-      for (ndx in output7) {
-        if (output7 !== undefined) {
-          paths7.push(join(__dirname, '/compare/output7' + output7[ndx].name));
+      for (ndx in output16) {
+        if (output16[ndx] !== undefined) {
+          paths16.push(join(__dirname, '/compare/output16' +
+            output16[ndx].name));
         }
       }
 
-      it('should still generate all paths with assert', function() {
+      it('should generate paths w/all consumes & produces \'xml\'', function() {
 
-        assert.isArray(output7);
-        assert.lengthOf(output7, 2);
+        assert.isArray(output16);
+        assert.lengthOf(output16, 2);
 
         var generatedCode;
 
-        for (ndx in paths7) {
-          if (paths7 !== undefined) {
-            generatedCode = read(paths7[ndx], 'utf8');
-            assert.equal(output7[ndx].test, generatedCode);
+        for (ndx in paths16) {
+          if (paths16[ndx] !== undefined) {
+            generatedCode = read(paths16[ndx], 'utf8');
+            assert.equal(output16[ndx].test, generatedCode);
           }
         }
 
-        for (ndx in output7) {
-          if (output7 !== undefined) {
-            assert.lengthOf(linter.verify(output7[ndx].test, rules), 0);
+        for (ndx in output16) {
+          if (output16 !== undefined) {
+            assert.lengthOf(linter.verify(output16[ndx].test, rules), 0);
           }
         }
       });
 
-      var output8 = testGen(swagger, {
-        assertionFormat: 'expect',
+      swagger.produces.push('application/json');
+
+      var output15 = testGen(swagger, {
+        assertionFormat: 'should',
+        pathName: [],
+        testModule: 'request'
+      });
+
+      var paths15 = [];
+
+      for (ndx in output15) {
+        if (output15[ndx] !== undefined) {
+          paths15.push(join(__dirname, '/compare/output15' +
+            output15[ndx].name));
+        }
+      }
+
+      it('should generate paths w/all consumes and all produces', function() {
+
+        assert.isArray(output15);
+        assert.lengthOf(output15, 2);
+
+        var generatedCode;
+
+        for (ndx in paths15) {
+          if (paths15[ndx] !== undefined) {
+            generatedCode = read(paths15[ndx], 'utf8');
+            assert.equal(output15[ndx].test, generatedCode);
+          }
+        }
+
+        for (ndx in output15) {
+          if (output15 !== undefined) {
+            assert.lengthOf(linter.verify(output15[ndx].test, rules), 0);
+          }
+        }
+      });
+
+      swagger.consumes = [];
+
+      var output14 = testGen(swagger, {
+        assertionFormat: 'should',
+        pathName: [],
+        testModule: 'request'
+      });
+
+      var paths14 = [];
+
+      for (ndx in output14) {
+        if (output14[ndx] !== undefined) {
+          paths14.push(join(__dirname, '/compare/output14' +
+            output14[ndx].name));
+        }
+      }
+
+      it('should generate paths w/default consumes & all produces', function() {
+
+        assert.isArray(output14);
+        assert.lengthOf(output14, 2);
+
+        var generatedCode;
+
+        for (ndx in paths14) {
+          if (paths14[ndx] !== undefined) {
+            generatedCode = read(paths14[ndx], 'utf8');
+            assert.equal(output14[ndx].test, generatedCode);
+          }
+        }
+
+        for (ndx in output14) {
+          if (output14 !== undefined) {
+            assert.lengthOf(linter.verify(output14[ndx].test, rules), 0);
+          }
+        }
+      });
+
+      swagger.consumes = [];
+      swagger.produces = [];
+    });
+  });
+
+  describe('supertest-option', function() {
+
+
+    describe('consumes', function() {
+      swagger.consumes = ['application/xml'];
+
+      var output9 = testGen(swagger, {
+        assertionFormat: 'should',
         pathName: [],
         testModule: 'supertest'
       });
 
-      var paths8 = [];
+      var paths9 = [];
+      var ndx;
 
-      for (ndx in output8) {
-        if (paths8 !== undefined) {
-          paths8.push(join(__dirname, '/compare/output8' + output8[ndx].name));
+      for (ndx in output9) {
+        if (paths9 !== undefined) {
+          paths9.push(join(__dirname, '/compare/output9' + output9[ndx].name));
         }
       }
 
-      it('should still generate all paths with expect', function() {
+      it('should generate all paths with \'xml\' comsumes', function() {
 
-        assert.isArray(output8);
-        assert.lengthOf(output8, 2);
+        assert.isArray(output9);
+        assert.lengthOf(output9, 2);
 
         var generatedCode;
 
-        for (ndx in paths8) {
-          if (paths8 !== undefined) {
-            generatedCode = read(paths8[ndx], 'utf8');
-            assert.equal(output8[ndx].test, generatedCode);
+        for (ndx in paths9) {
+          if (paths9 !== undefined) {
+            generatedCode = read(paths9[ndx], 'utf8');
+            assert.equal(output9[ndx].test, generatedCode);
           }
         }
 
-        for (ndx in output8) {
-          if (output8 !== undefined) {
-            assert.lengthOf(linter.verify(output8[ndx].test, rules), 0);
+        for (ndx in output9) {
+          if (output9 !== undefined) {
+            assert.lengthOf(linter.verify(output9[ndx].test, rules), 0);
+          }
+        }
+      });
+
+      swagger.consumes.push('application/json');
+
+      var output10 = testGen(swagger, {
+        assertionFormat: 'should',
+        pathName: [],
+        testModule: 'supertest'
+      });
+
+      var paths10 = [];
+
+      for (ndx in output10) {
+        if (output10[ndx] !== undefined) {
+          paths10.push(join(__dirname, '/compare/output10'
+            + output10[ndx].name));
+        }
+      }
+
+      it('should generate paths with \'xml\' & \'json\' comsumes', function() {
+
+        assert.isArray(output10);
+        assert.lengthOf(output10, 2);
+
+        var generatedCode;
+
+        for (ndx in paths10) {
+          if (paths10[ndx] !== undefined) {
+            generatedCode = read(paths10[ndx], 'utf8');
+            assert.equal(output10[ndx].test, generatedCode);
+          }
+        }
+
+        for (ndx in output10) {
+          if (output10 !== undefined) {
+            assert.lengthOf(linter.verify(output10[ndx].test, rules), 0);
+          }
+        }
+      });
+    });
+
+    describe('produces', function() {
+      swagger.produces = ['application/xml'];
+
+      var output11 = testGen(swagger, {
+        assertionFormat: 'should',
+        pathName: [],
+        testModule: 'supertest'
+      });
+
+      var paths11 = [];
+      var ndx;
+
+      for (ndx in output11) {
+        if (output11[ndx] !== undefined) {
+          paths11.push(join(__dirname, '/compare/output11'
+            + output11[ndx].name));
+        }
+      }
+
+      it('should generate paths w/all consumes & produces \'xml\'', function() {
+
+        assert.isArray(output11);
+        assert.lengthOf(output11, 2);
+
+        var generatedCode;
+
+        for (ndx in paths11) {
+          if (paths11[ndx] !== undefined) {
+            generatedCode = read(paths11[ndx], 'utf8');
+            assert.equal(output11[ndx].test, generatedCode);
+          }
+        }
+
+        for (ndx in output11) {
+          if (output11 !== undefined) {
+            assert.lengthOf(linter.verify(output11[ndx].test, rules), 0);
+          }
+        }
+      });
+
+      swagger.produces.push('application/json');
+
+      var output12 = testGen(swagger, {
+        assertionFormat: 'should',
+        pathName: [],
+        testModule: 'supertest'
+      });
+
+      var paths12 = [];
+
+      for (ndx in output12) {
+        if (output12[ndx] !== undefined) {
+          paths12.push(join(__dirname, '/compare/output12'
+            + output12[ndx].name));
+        }
+      }
+
+      it('should generate paths w/all consumes and all produces', function() {
+
+        assert.isArray(output12);
+        assert.lengthOf(output12, 2);
+
+        var generatedCode;
+
+        for (ndx in paths12) {
+          if (paths12[ndx] !== undefined) {
+            generatedCode = read(paths12[ndx], 'utf8');
+            assert.equal(output12[ndx].test, generatedCode);
+          }
+        }
+
+        for (ndx in output12) {
+          if (output12 !== undefined) {
+            assert.lengthOf(linter.verify(output12[ndx].test, rules), 0);
+          }
+        }
+      });
+
+      swagger.consumes = [];
+
+      var output13 = testGen(swagger, {
+        assertionFormat: 'should',
+        pathName: [],
+        testModule: 'supertest'
+      });
+
+      var paths13 = [];
+
+      for (ndx in output13) {
+        if (output13[ndx] !== undefined) {
+          paths13.push(join(__dirname, '/compare/output13'
+            + output13[ndx].name));
+        }
+      }
+
+      it('should generate paths w/default consumes & all produces', function() {
+
+        assert.isArray(output13);
+        assert.lengthOf(output13, 2);
+
+        var generatedCode;
+
+        for (ndx in paths13) {
+          if (paths13[ndx] !== undefined) {
+            generatedCode = read(paths13[ndx], 'utf8');
+            assert.equal(output13[ndx].test, generatedCode);
+          }
+        }
+
+        for (ndx in output13) {
+          if (output13 !== undefined) {
+            assert.lengthOf(linter.verify(output13[ndx].test, rules), 0);
           }
         }
       });


### PR DESCRIPTION
Now generates tests for all combinations of content types specified in the ```consumes``` and ```produces ``` properties.

Fixes #20 