### PR TITLE
operation consume/produce/security is always defined 

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,6 +36,7 @@ var schemaTemp;
 var importValidator = false;
 var consumes;
 var produces;
+var security;
 
 /**
  * To check if it is an empty array or undefined
@@ -73,7 +74,7 @@ function getData(swagger, path, operation, response, config) {
     headerParameters: [],
     pathParameters: [],
     formParameters: [],
-    security: swagger.security,
+    security: security,
     path: ''
   };
 
@@ -135,14 +136,6 @@ function getData(swagger, path, operation, response, config) {
     data.noSchema = false;
     data.schema = grandProperty.responses[response].schema;
     data.schema = JSON.stringify(data.schema, null, 2);
-  }
-
-  if (childProperty.hasOwnProperty('security')) {
-    data.returnType = swagger.paths[path][operation].security;
-  }
-
-  if (grandProperty.hasOwnProperty('security')) {
-    data.returnType = swagger.paths[path][operation].security;
   }
 
   // request url case
@@ -278,6 +271,14 @@ function testGenOperation(swagger, path, operation, config) {
     consumes = swagger.consumes;
   } else {
     consumes = [];
+  }
+
+  if (!isEmpty(swagger.paths[path][operation].security)) {
+    security = swagger.paths[path][operation].security;
+  } else if (!isEmpty(swagger.security)) {
+    security = swagger.security;
+  } else {
+    security = [];
   }
 
   for (res in responses) {

--- a/index.js
+++ b/index.js
@@ -257,6 +257,7 @@ function testGenOperation(swagger, path, operation, config) {
   var result = [];
   var res;
 
+  // determines which produce types to use
   if (!isEmpty(swagger.paths[path][operation].produces)) {
     produces = swagger.paths[path][operation].produces;
   } else if (!isEmpty(swagger.produces)) {
@@ -265,6 +266,7 @@ function testGenOperation(swagger, path, operation, config) {
     produces = [];
   }
 
+  // determines which consumes types to use
   if (!isEmpty(swagger.paths[path][operation].consumes)) {
     consumes = swagger.paths[path][operation].consumes;
   } else if (!isEmpty(swagger.consumes)) {
@@ -273,6 +275,7 @@ function testGenOperation(swagger, path, operation, config) {
     consumes = [];
   }
 
+  // determines which security to use
   if (!isEmpty(swagger.paths[path][operation].security)) {
     security = swagger.paths[path][operation].security;
   } else if (!isEmpty(swagger.security)) {

--- a/index.js
+++ b/index.js
@@ -34,6 +34,8 @@ var innerDescribeFn;
 var outerDescribeFn;
 var schemaTemp;
 var importValidator = false;
+var consumes;
+var produces;
 
 /**
  * To check if it is an empty array or undefined
@@ -210,10 +212,6 @@ function testGenResponse(swagger, path, operation, response, config,
 
 function testGenContentTypes(swagger, path, operation, res, config) {
   var result = [];
-  var produces = swagger.paths[path][operation].produces ?
-    swagger.paths[path][operation].produces : swagger.produces;
-  var consumes = swagger.paths[path][operation].consumes ?
-    swagger.paths[path][operation].consumes : swagger.consumes;
   var ndxC;
   var ndxP;
 
@@ -265,6 +263,22 @@ function testGenOperation(swagger, path, operation, config) {
   var responses = swagger.paths[path][operation].responses;
   var result = [];
   var res;
+
+  if (!isEmpty(swagger.paths[path][operation].produces)) {
+    produces = swagger.paths[path][operation].produces;
+  } else if (!isEmpty(swagger.produces)) {
+    produces = swagger.produces;
+  } else {
+    produces = [];
+  }
+
+  if (!isEmpty(swagger.paths[path][operation].consumes)) {
+    consumes = swagger.paths[path][operation].consumes;
+  } else if (!isEmpty(swagger.consumes)) {
+    consumes = swagger.consumes;
+  } else {
+    consumes = [];
+  }
 
   for (res in responses) {
     if (responses.hasOwnProperty(res)) {

--- a/test/minimal/test.js
+++ b/test/minimal/test.js
@@ -357,7 +357,7 @@ describe('minimal swagger', function() {
         }
       }
 
-      it('should generate paths w/default consumes & produces', function() {
+      it('should generate paths w/default consumes & all produces', function() {
 
         assert.isArray(output14);
         assert.lengthOf(output14, 1);


### PR DESCRIPTION
simplifies the cascading properties (consumes/produces/security) by only evaluating at the operation level rather than at the response level of test generation.

Fixes #41 