### PR TITLE
Add support for path parameters to handlebars `pathify`

### DIFF
--- a/templates/request/delete/delete.handlebars
+++ b/templates/request/delete/delete.handlebars
@@ -6,7 +6,7 @@
       /*eslint-enable*/
       {{/validateResponse}}
       request({
-        url: '{{pathify path}}',
+        url: '{{pathify path pathParams}}',
         {{#ifCond queryParameters queryApiKey}}
         qs: {
           {{#if queryApiKey}}{{queryApiKey.type}}: process.env.{{queryApiKey.name}}{{#if queryParameters}},

--- a/templates/request/get/get.handlebars
+++ b/templates/request/get/get.handlebars
@@ -6,7 +6,7 @@
       /*eslint-enable*/
       {{/validateResponse}}
       request({
-        url: '{{pathify path}}',
+        url: '{{pathify path pathParams}}',
         {{#ifCond queryParameters queryApiKey}}
         qs: {
           {{#if queryApiKey}}{{queryApiKey.type}}: process.env.{{queryApiKey.name}}{{#if queryParameters}},
@@ -78,7 +78,7 @@
         concurrentRequests: {{concurrent}},
         targetFunction: function(callback) {
           request({
-            url: '{{pathify path}}',
+            url: '{{pathify path pathParams}}',
             {{#ifCond queryParameters queryApiKey}}
             qs: {
               {{#if queryApiKey}}{{queryApiKey.type}}: process.env.{{queryApiKey.name}}{{#if queryParameters}},

--- a/templates/request/head/head.handlebars
+++ b/templates/request/head/head.handlebars
@@ -6,7 +6,7 @@
       /*eslint-enable*/
       {{/validateResponse}}
       request({
-        url: '{{pathify path}}',
+        url: '{{pathify path pathParams}}',
         {{#ifCond queryParameters queryApiKey}}
         qs: {
           {{#if queryApiKey}}{{queryApiKey.type}}: process.env.{{queryApiKey.name}}{{#if queryParameters}},

--- a/templates/request/patch/patch.handlebars
+++ b/templates/request/patch/patch.handlebars
@@ -6,7 +6,7 @@
       /*eslint-enable*/
       {{/validateResponse}}
       request({
-        url: '{{pathify path}}',
+        url: '{{pathify path pathParams}}',
         {{#ifCond queryParameters queryApiKey}}
         qs: {
           {{#if queryApiKey}}{{queryApiKey.type}}: process.env.{{queryApiKey.name}}{{#if queryParameters}},
@@ -104,7 +104,7 @@
         concurrentRequests: {{concurrent}},
         targetFunction: function(callback) {
           request({
-            url: '{{pathify path}}',
+            url: '{{pathify path pathParams}}',
             {{#ifCond queryParameters queryApiKey}}
             qs: {
               {{#if queryApiKey}}{{queryApiKey.type}}: process.env.{{queryApiKey.name}}{{#if queryParameters}},

--- a/templates/request/post/post.handlebars
+++ b/templates/request/post/post.handlebars
@@ -6,7 +6,7 @@
       /*eslint-enable*/
       {{/validateResponse}}
       request({
-        url: '{{pathify path}}',
+        url: '{{pathify path pathParams}}',
         {{#ifCond queryParameters queryApiKey}}
         qs: {
           {{#if queryApiKey}}{{queryApiKey.type}}: process.env.{{queryApiKey.name}}{{#if queryParameters}},
@@ -105,7 +105,7 @@
         concurrentRequests: {{concurrent}},
         targetFunction: function(callback) {
           request({
-            url: '{{pathify path}}',
+            url: '{{pathify path pathParams}}',
             {{#ifCond queryParameters queryApiKey}}
             qs: {
               {{#if queryApiKey}}{{queryApiKey.type}}: process.env.{{queryApiKey.name}}{{#if queryParameters}},

--- a/templates/request/put/put.handlebars
+++ b/templates/request/put/put.handlebars
@@ -6,7 +6,7 @@
       /*eslint-enable*/
       {{/validateResponse}}
       request({
-        url: '{{pathify path}}',
+        url: '{{pathify path pathParams}}',
         {{#ifCond queryParameters queryApiKey}}
         qs: {
           {{#if queryApiKey}}{{queryApiKey.type}}: process.env.{{queryApiKey.name}}{{#if queryParameters}},
@@ -105,7 +105,7 @@
         concurrentRequests: {{concurrent}},
         targetFunction: function(callback) {
           request({
-            url: '{{pathify path}}',
+            url: '{{pathify path pathParams}}',
             {{#ifCond queryParameters queryApiKey}}
             qs: {
               {{#if queryApiKey}}{{queryApiKey.type}}: process.env.{{queryApiKey.name}}{{#if queryParameters}},

--- a/templates/supertest/delete/delete.handlebars
+++ b/templates/supertest/delete/delete.handlebars
@@ -5,7 +5,7 @@
 
       /*eslint-enable*/
       {{/validateResponse}}
-      api.del('{{pathify path}}')
+      api.del('{{pathify path pathParams}}')
       {{#ifCond queryParameters queryApiKey}}
       .query({
         {{#if queryApiKey}}

--- a/templates/supertest/get/get.handlebars
+++ b/templates/supertest/get/get.handlebars
@@ -5,7 +5,7 @@
 
       /*eslint-enable*/
       {{/validateResponse}}
-      api.get('{{pathify path}}')
+      api.get('{{pathify path pathParams}}')
       {{#ifCond queryParameters queryApiKey}}
       .query({
         {{#if queryApiKey}}
@@ -66,7 +66,7 @@
         requests: {{requests}},
         concurrentRequests: {{concurrent}},
         targetFunction: function(callback) {
-          api.get('{{pathify path}}')
+          api.get('{{pathify path pathParams}}')
           {{#ifCond queryParameters queryApiKey}}
           .query({
             {{#if queryApiKey}}

--- a/templates/supertest/head/head.handlebars
+++ b/templates/supertest/head/head.handlebars
@@ -5,7 +5,7 @@
 
       /*eslint-enable*/
       {{/validateResponse}}
-      api.head('{{pathify path}}')
+      api.head('{{pathify path pathParams}}')
       {{#ifCond queryParameters queryApiKey}}
       .query({
         {{#if queryApiKey}}

--- a/templates/supertest/options/options.handlebars
+++ b/templates/supertest/options/options.handlebars
@@ -5,7 +5,7 @@
 
       /*eslint-enable*/
       {{/validateResponse}}
-      api.options('{{pathify path}}')
+      api.options('{{pathify path pathParams}}')
       {{#ifCond queryParameters queryApiKey}}
       .query({
         {{#if queryApiKey}}
@@ -66,7 +66,7 @@
         requests: {{requests}},
         concurrentRequests: {{concurrent}},
         targetFunction: function(callback) {
-          api.options('{{pathify path}}')
+          api.options('{{pathify path pathParams}}')
           {{#ifCond queryParameters queryApiKey}}
           .query({
             {{#if queryApiKey}}

--- a/templates/supertest/patch/patch.handlebars
+++ b/templates/supertest/patch/patch.handlebars
@@ -5,7 +5,7 @@
 
       /*eslint-enable*/
       {{/validateResponse}}
-      api.patch('{{pathify path}}')
+      api.patch('{{pathify path pathParams}}')
       {{#ifCond queryParameters queryApiKey}}
       .query({
         {{#if queryApiKey}}
@@ -87,7 +87,7 @@
         requests: {{requests}},
         concurrentRequests: {{concurrent}},
         targetFunction: function(callback) {
-          api.patch('{{pathify path}}')
+          api.patch('{{pathify path pathParams}}')
           {{#ifCond queryParameters queryApiKey}}
           .query({
             {{#if queryApiKey}}{{queryApiKey.type}}: process.env.{{queryApiKey.name}}{{#if queryParameters}},

--- a/templates/supertest/post/post.handlebars
+++ b/templates/supertest/post/post.handlebars
@@ -5,7 +5,7 @@
 
       /*eslint-enable*/
       {{/validateResponse}}
-      api.post('{{pathify path}}')
+      api.post('{{pathify path pathParams}}')
       {{#ifCond queryParameters queryApiKey}}
       .query({
         {{#if queryApiKey}}{{queryApiKey.type}}: process.env.{{queryApiKey.name}}{{#if queryParameters}},
@@ -86,7 +86,7 @@
         requests: {{requests}},
         concurrentRequests: {{concurrent}},
         targetFunction: function(callback) {
-          api.post('{{pathify path}}')
+          api.post('{{pathify path pathParams}}')
           {{#ifCond queryParameters queryApiKey}}
           .query({
             {{#if queryApiKey}}{{queryApiKey.type}}: process.env.{{queryApiKey.name}}{{#if queryParameters}},

--- a/templates/supertest/put/put.handlebars
+++ b/templates/supertest/put/put.handlebars
@@ -5,7 +5,7 @@
 
       /*eslint-enable*/
       {{/validateResponse}}
-      api.put('{{pathify path}}')
+      api.put('{{pathify path pathParams}}')
       {{#ifCond queryParameters queryApiKey}}
       .query({
         {{#if queryApiKey}}{{queryApiKey.type}}: process.env.{{queryApiKey.name}}{{#if queryParameters}},
@@ -86,7 +86,7 @@
         requests: {{requests}},
         concurrentRequests: {{concurrent}},
         targetFunction: function(callback) {
-          api.put('{{pathify path}}')
+          api.put('{{pathify path pathParams}}')
           {{#ifCond queryParameters queryApiKey}}
           .query({
             {{#if queryApiKey}}{{queryApiKey.type}}: process.env.{{queryApiKey.name}}{{#if queryParameters}},

--- a/test/pathParam/compare/output3-{id}-test.js
+++ b/test/pathParam/compare/output3-{id}-test.js
@@ -1,0 +1,37 @@
+'use strict';
+var chai = require('chai');
+var supertest = require('supertest');
+var api = supertest('http://localhost:10010'); // supertest init;
+
+chai.should();
+
+describe('/{id}', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      api.get('/userSuppliedID')
+      .set('Accept', 'application/json')
+      .expect(200)
+      .end(function(err, res) {
+        if (err) return done(err);
+
+        res.body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+  });
+
+  describe('head', function() {
+    it('should respond with 200 OK', function(done) {
+      api.head('/userSuppliedID')
+      .set('Accept', 'application/json')
+      .expect(200)
+      .end(function(err) {
+        if (err) return done(err);
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/pathParam/test.js
+++ b/test/pathParam/test.js
@@ -116,4 +116,47 @@ describe('pathParams swagger', function() {
       });
     });
   });
+
+  describe('user-supplied', function() {
+    describe('pathParams', function() {
+      var output3 = testGen(swagger, {
+        assertionFormat: 'should',
+        pathName: [],
+        testModule: 'supertest',
+        pathParams: {
+          id: 'userSuppliedID'
+        }
+      });
+
+      var paths3 = [];
+      var ndx;
+
+      for (ndx in output3) {
+        if (output3) {
+          paths3.push(join(__dirname, '/compare/output3-' + output3[ndx].name));
+        }
+      }
+
+
+      it('should have a path parameter where "{id}" was', function() {
+        assert.isArray(output3);
+        assert.lengthOf(output3, 1);
+
+        var generatedCode;
+
+        for (ndx in paths3) {
+          if (paths3 !== undefined) {
+            generatedCode = read(paths3[ndx], 'utf8').replace(/\r\n/g, '\n');
+            assert.equal(output3[ndx].test, generatedCode);
+          }
+        }
+
+        for (ndx in output3) {
+          if (output3 !== undefined) {
+            assert.lengthOf(linter.verify(output3[ndx].test, rules), 0);
+          }
+        }
+      });
+    });
+  });
 });


### PR DESCRIPTION
- A few quick tests seem to indicate that this works fine
- Was designed to replace multiple parameters, but needs to be tested
further
- Could probably be optimized down to a few lines, but this was
quick'n'dirty :)
- No error checking on value of pathParam -- should probably only be
allowed to be javascript native
- Only works globally -- I wonder if there is a way to make this easier
to do in a per-path fashion (right now, selfishly, it serves the purpose
I need it for)