### PR TITLE
Added ignoreUnknownFormats to ZSchema

### DIFF
--- a/templates/outerDescribe.handlebars
+++ b/templates/outerDescribe.handlebars
@@ -1,7 +1,9 @@
 'use strict';
 var chai = require('chai');{{#if importValidator}}
 var ZSchema = require('z-schema');
-var validator = new ZSchema({});{{/if}}
+var validator = new ZSchema({
+  ignoreUnknownFormats: true
+});{{/if}}
 {{#is testmodule 'request'}}
 var request = require('request');
 {{/is}}


### PR DESCRIPTION
This PR prevents errors for the tests that need to validate against a schema with a format defined, such as with objects with an integer (int32) key. The solution is very simple and it is derived from https://github.com/swagger-api/swagger-editor/issues/612.
Let me know if any additional work is needed to accept it.