### PR TITLE
Normalizing CRLF in test assertions

### DIFF
--- a/test/deprecated/test.js
+++ b/test/deprecated/test.js
@@ -64,8 +64,9 @@ describe('deprecated swagger', function() {
 
         for (ndx in paths1) {
           if (paths1 !== undefined) {
-            generatedCode = read(paths1[ndx], 'utf8');
-            assert.equal(output1[ndx].test, generatedCode);
+            generatedCode = read(paths1[ndx], 'utf8').replace(/\r\n/g, '\n');
+            assert.equal(output1[ndx].test.replace(/\r\n/g, '\n'),
+              generatedCode);
           }
         }
 

--- a/test/loadTest/test.js
+++ b/test/loadTest/test.js
@@ -66,8 +66,9 @@ describe('security swagger', function() {
 
         for (ndx in paths1) {
           if (paths1 !== undefined) {
-            generatedCode = read(paths1[ndx], 'utf8');
-            assert.equal(output1[ndx].test, generatedCode);
+            generatedCode = read(paths1[ndx], 'utf8').replace(/\r\n/g, '\n');
+            assert.equal(output1[ndx].test.replace(/\r\n/g, '\n'),
+              generatedCode);
           }
         }
 
@@ -109,8 +110,9 @@ describe('security swagger', function() {
 
         for (ndx in paths2) {
           if (paths2 !== undefined) {
-            generatedCode = read(paths2[ndx], 'utf8');
-            assert.equal(output2[ndx].test, generatedCode);
+            generatedCode = read(paths2[ndx], 'utf8').replace(/\r\n/g, '\n');
+            assert.equal(output2[ndx].test.replace(/\r\n/g, '\n'),
+              generatedCode);
           }
         }
 
@@ -152,8 +154,9 @@ describe('security swagger', function() {
 
         for (ndx in paths2) {
           if (paths2 !== undefined) {
-            generatedCode = read(paths2[ndx], 'utf8');
-            assert.equal(output2[ndx].test, generatedCode);
+            generatedCode = read(paths2[ndx], 'utf8').replace(/\r\n/g, '\n');
+            assert.equal(output2[ndx].test.replace(/\r\n/g, '\n'),
+              generatedCode);
           }
         }
 
@@ -195,8 +198,9 @@ describe('security swagger', function() {
 
         for (ndx in paths2) {
           if (paths2 !== undefined) {
-            generatedCode = read(paths2[ndx], 'utf8');
-            assert.equal(output2[ndx].test, generatedCode);
+            generatedCode = read(paths2[ndx], 'utf8').replace(/\r\n/g, '\n');
+            assert.equal(output2[ndx].test.replace(/\r\n/g, '\n'),
+              generatedCode);
           }
         }
 
@@ -240,8 +244,9 @@ describe('security swagger', function() {
 
         for (ndx in paths2) {
           if (paths2 !== undefined) {
-            generatedCode = read(paths2[ndx], 'utf8');
-            assert.equal(output2[ndx].test, generatedCode);
+            generatedCode = read(paths2[ndx], 'utf8').replace(/\r\n/g, '\n');
+            assert.equal(output2[ndx].test.replace(/\r\n/g, '\n'),
+              generatedCode);
           }
         }
 
@@ -285,8 +290,9 @@ describe('security swagger', function() {
 
         for (ndx in paths2) {
           if (paths2 !== undefined) {
-            generatedCode = read(paths2[ndx], 'utf8');
-            assert.equal(output2[ndx].test, generatedCode);
+            generatedCode = read(paths2[ndx], 'utf8').replace(/\r\n/g, '\n');
+            assert.equal(output2[ndx].test.replace(/\r\n/g, '\n'),
+              generatedCode);
           }
         }
 

--- a/test/minimal/test.js
+++ b/test/minimal/test.js
@@ -64,8 +64,9 @@ describe('security swagger', function() {
 
         for (ndx in paths1) {
           if (paths1 !== undefined) {
-            generatedCode = read(paths1[ndx], 'utf8');
-            assert.equal(output1[ndx].test, generatedCode);
+            generatedCode = read(paths1[ndx], 'utf8').replace(/\r\n/g, '\n');
+            assert.equal(output1[ndx].test.replace(/\r\n/g, '\n'),
+              generatedCode);
           }
         }
 
@@ -105,8 +106,9 @@ describe('security swagger', function() {
 
         for (ndx in paths2) {
           if (paths2 !== undefined) {
-            generatedCode = read(paths2[ndx], 'utf8');
-            assert.equal(output2[ndx].test, generatedCode);
+            generatedCode = read(paths2[ndx], 'utf8').replace(/\r\n/g, '\n');
+            assert.equal(output2[ndx].test.replace(/\r\n/g, '\n'),
+              generatedCode);
           }
         }
 
@@ -146,8 +148,9 @@ describe('security swagger', function() {
 
         for (ndx in paths2) {
           if (paths2 !== undefined) {
-            generatedCode = read(paths2[ndx], 'utf8');
-            assert.equal(output2[ndx].test, generatedCode);
+            generatedCode = read(paths2[ndx], 'utf8').replace(/\r\n/g, '\n');
+            assert.equal(output2[ndx].test.replace(/\r\n/g, '\n'),
+              generatedCode);
           }
         }
 
@@ -187,8 +190,9 @@ describe('security swagger', function() {
 
         for (ndx in paths2) {
           if (paths2 !== undefined) {
-            generatedCode = read(paths2[ndx], 'utf8');
-            assert.equal(output2[ndx].test, generatedCode);
+            generatedCode = read(paths2[ndx], 'utf8').replace(/\r\n/g, '\n');
+            assert.equal(output2[ndx].test.replace(/\r\n/g, '\n'),
+              generatedCode);
           }
         }
 
@@ -228,8 +232,9 @@ describe('security swagger', function() {
 
         for (ndx in paths2) {
           if (paths2 !== undefined) {
-            generatedCode = read(paths2[ndx], 'utf8');
-            assert.equal(output2[ndx].test, generatedCode);
+            generatedCode = read(paths2[ndx], 'utf8').replace(/\r\n/g, '\n');
+            assert.equal(output2[ndx].test.replace(/\r\n/g, '\n'),
+              generatedCode);
           }
         }
 
@@ -269,8 +274,9 @@ describe('security swagger', function() {
 
         for (ndx in paths2) {
           if (paths2 !== undefined) {
-            generatedCode = read(paths2[ndx], 'utf8');
-            assert.equal(output2[ndx].test, generatedCode);
+            generatedCode = read(paths2[ndx], 'utf8').replace(/\r\n/g, '\n');
+            assert.equal(output2[ndx].test.replace(/\r\n/g, '\n'),
+              generatedCode);
           }
         }
 

--- a/test/pathParam/test.js
+++ b/test/pathParam/test.js
@@ -63,8 +63,9 @@ describe('pathParams swagger', function() {
 
         for (ndx in paths1) {
           if (paths1 !== undefined) {
-            generatedCode = read(paths1[ndx], 'utf8');
-            assert.equal(output1[ndx].test, generatedCode);
+            generatedCode = read(paths1[ndx], 'utf8').replace(/\r\n/g, '\n');
+            assert.equal(output1[ndx].test.replace(/\r\n/g, '\n'),
+              generatedCode);
           }
         }
 
@@ -103,8 +104,9 @@ describe('pathParams swagger', function() {
 
         for (ndx in paths2) {
           if (paths2 !== undefined) {
-            generatedCode = read(paths2[ndx], 'utf8');
-            assert.equal(output2[ndx].test, generatedCode);
+            generatedCode = read(paths2[ndx], 'utf8').replace(/\r\n/g, '\n');
+            assert.equal(output2[ndx].test.replace(/\r\n/g, '\n'),
+              generatedCode);
           }
         }
 
@@ -147,7 +149,8 @@ describe('pathParams swagger', function() {
         for (ndx in paths3) {
           if (paths3 !== undefined) {
             generatedCode = read(paths3[ndx], 'utf8').replace(/\r\n/g, '\n');
-            assert.equal(output3[ndx].test, generatedCode);
+            assert.equal(output3[ndx].test.replace(/\r\n/g, '\n'),
+              generatedCode);
           }
         }
 

--- a/test/robust/test.js
+++ b/test/robust/test.js
@@ -64,8 +64,9 @@ describe('security swagger', function() {
 
         for (ndx in paths1) {
           if (paths1 !== undefined) {
-            generatedCode = read(paths1[ndx], 'utf8');
-            assert.equal(output1[ndx].test, generatedCode);
+            generatedCode = read(paths1[ndx], 'utf8').replace(/\r\n/g, '\n');
+            assert.equal(output1[ndx].test.replace(/\r\n/g, '\n'),
+              generatedCode);
           }
         }
 
@@ -105,8 +106,9 @@ describe('security swagger', function() {
 
         for (ndx in paths2) {
           if (paths2 !== undefined) {
-            generatedCode = read(paths2[ndx], 'utf8');
-            assert.equal(output2[ndx].test, generatedCode);
+            generatedCode = read(paths2[ndx], 'utf8').replace(/\r\n/g, '\n');
+            assert.equal(output2[ndx].test.replace(/\r\n/g, '\n'),
+              generatedCode);
           }
         }
 
@@ -146,8 +148,9 @@ describe('security swagger', function() {
 
         for (ndx in paths2) {
           if (paths2 !== undefined) {
-            generatedCode = read(paths2[ndx], 'utf8');
-            assert.equal(output2[ndx].test, generatedCode);
+            generatedCode = read(paths2[ndx], 'utf8').replace(/\r\n/g, '\n');
+            assert.equal(output2[ndx].test.replace(/\r\n/g, '\n'),
+              generatedCode);
           }
         }
 
@@ -187,8 +190,9 @@ describe('security swagger', function() {
 
         for (ndx in paths2) {
           if (paths2 !== undefined) {
-            generatedCode = read(paths2[ndx], 'utf8');
-            assert.equal(output2[ndx].test, generatedCode);
+            generatedCode = read(paths2[ndx], 'utf8').replace(/\r\n/g, '\n');
+            assert.equal(output2[ndx].test.replace(/\r\n/g, '\n'),
+              generatedCode);
           }
         }
 
@@ -228,8 +232,9 @@ describe('security swagger', function() {
 
         for (ndx in paths2) {
           if (paths2 !== undefined) {
-            generatedCode = read(paths2[ndx], 'utf8');
-            assert.equal(output2[ndx].test, generatedCode);
+            generatedCode = read(paths2[ndx], 'utf8').replace(/\r\n/g, '\n');
+            assert.equal(output2[ndx].test.replace(/\r\n/g, '\n'),
+              generatedCode);
           }
         }
 
@@ -269,8 +274,9 @@ describe('security swagger', function() {
 
         for (ndx in paths2) {
           if (paths2 !== undefined) {
-            generatedCode = read(paths2[ndx], 'utf8');
-            assert.equal(output2[ndx].test, generatedCode);
+            generatedCode = read(paths2[ndx], 'utf8').replace(/\r\n/g, '\n');
+            assert.equal(output2[ndx].test.replace(/\r\n/g, '\n'),
+              generatedCode);
           }
         }
 

--- a/test/security/test.js
+++ b/test/security/test.js
@@ -104,8 +104,9 @@ describe('security swagger', function() {
 
         for (ndx in paths2) {
           if (paths2 !== undefined) {
-            generatedCode = read(paths2[ndx], 'utf8');
-            assert.equal(output2[ndx].test, generatedCode);
+            generatedCode = read(paths2[ndx], 'utf8').replace(/\r\n/g, '\n');
+            assert.equal(output2[ndx].test.replace(/\r\n/g, '\n'),
+              generatedCode);
           }
         }
 


### PR DESCRIPTION
When a contribution comes in by way of Windows, I believe it causes test failures due to the difference in line endings..

https://travis-ci.org/apigee-127/swagger-test-templates/jobs/110661936

1) security swagger assert-option expect should have path parameters with an obvious indicator:

I added some CRLF line feed normalization to the tests. There are probably other ways to do this, such as forcing conversion upon check-in, but the method used herein was also used in at least [one other location](https://github.com/apigee-127/swagger-test-templates/blob/master/test/pathParam/test.js#L149).
