### PR TITLE
Dereference swagger before test generation.

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,6 +32,7 @@ var read = require('fs').readFileSync;
 var _ = require('lodash');
 var strObj = require('string');
 var join = require('path').join;
+var deref = require('json-schema-deref-sync');
 var len;
 
 /**
@@ -424,7 +425,7 @@ function testGen(swagger, config) {
   var environment;
   var ndx = 0;
 
-
+  swagger = deref(swagger);
   source = read(join(__dirname, 'templates/schema.handlebars'), 'utf8');
   schemaTemp = handlebars.compile(source, {noEscape: true});
   handlebars.registerPartial('schema-partial', schemaTemp);

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
   },
   "dependencies": {
     "handlebars": "^3.0.3",
+    "json-schema-deref-sync": "^0.3.1",
     "lodash": "^3.10.0",
     "sanitize-filename": "^1.3.0",
     "string": "^3.3.0"

--- a/test/dereferencing/swagger-resolved.json
+++ b/test/dereferencing/swagger-resolved.json
@@ -1,0 +1,61 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "0.0.1",
+    "title": "Travel Groups App"
+  },
+  "host": "localhost:10010",
+  "basePath": "/",
+  "schemes": [
+    "http",
+    "https"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "paths": {
+    "/user": {
+      "get": {
+        "summary": "Show current user",
+        "responses": {
+          "200": {
+            "description": "The requested user",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "data": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string",
+                      "description": "Resource ID"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "User’s public name"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "User": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Resource ID"
+        },
+        "name": {
+          "type": "string",
+          "description": "User’s public name"
+        }
+      }
+    }
+  }
+}

--- a/test/dereferencing/swagger-with-ref.json
+++ b/test/dereferencing/swagger-with-ref.json
@@ -1,0 +1,51 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "0.0.1",
+    "title": "Travel Groups App"
+  },
+  "host": "localhost:10010",
+  "basePath": "/",
+  "schemes": [
+    "http",
+    "https"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "paths": {
+    "/user": {
+      "get": {
+        "summary": "Show current user",
+        "responses": {
+          "200": {
+            "description": "The requested user",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "data": {
+                  "$ref": "#/definitions/User"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "User": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Resource ID"
+        },
+        "name": {
+          "type": "string",
+          "description": "User’s public name"
+        }
+      }
+    }
+  }
+}

--- a/test/dereferencing/test.js
+++ b/test/dereferencing/test.js
@@ -1,0 +1,41 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Apigee Corporation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+'use strict';
+
+var expect = require('chai').expect;
+var swaggerWithRef = require('./swagger-with-ref.json');
+var swaggerResolved = require('./swagger-resolved.json');
+var deref = require('json-schema-deref-sync');
+
+describe('Test json-schema-deref-sync module', function() {
+  describe('Test resolving swagger references', function() {
+    it('should return a json with the references resolved',
+      function() {
+      var resolved = deref(swaggerWithRef);
+
+      expect(resolved).to.eql(swaggerResolved);
+    });
+  });
+});


### PR DESCRIPTION
Run [json-schema-deref-sync](https://www.npmjs.com/package/json-schema-deref-sync) on the passed in swagger before the test generation process begins, so that references ($ref) are resolved and the schema validator can correctly validate.

Discussion here: https://github.com/apigee-127/swagger-test-templates/issues/92