### PR TITLE
Feature/add new swagger schematypes

### DIFF
--- a/custom-formats.js
+++ b/custom-formats.js
@@ -1,0 +1,45 @@
+/**
+ * Placeholder file for all custom-formats in known to swagger.json
+ * as found on
+ * https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#dataTypeFormat
+ */
+
+var decimalPattern = /^\d{0,8}.?\d{0,4}[0]+$/;
+
+exports = module.exports = function(ZSchema) {
+
+  /** Validates floating point as decimal / money (i.e: 12345678.123400..) */
+  ZSchema.registerFormat("double", function(val) {
+    return !decimalPattern.test(val.toString());
+  });
+
+  /** Validates value is a 32bit integer */
+  ZSchema.registerFormat("int32", function(val) {
+    // the 32bit shift (>>) truncates any bits beyond max of 32
+    return Number.isInteger(val) && ((val >> 0) === val);
+  });
+
+  ZSchema.registerFormat("int64", function(val) {
+    return Number.isInteger(val);
+  });
+
+  ZSchema.registerFormat("float", function(val) {
+    // should parse
+    return Number.isInteger(val);
+  });
+
+  ZSchema.registerFormat("date", function(val) {
+    // should parse a a date
+    return !isNaN(Date.parse(val));
+  });
+
+  ZSchema.registerFormat("dateTime", function(val) {
+    return !isNaN(Date.parse(val));
+  });
+
+  ZSchema.registerFormat("password", function(val) {
+    // should parse as a string
+    return typeof val === 'string'
+  });
+
+};

--- a/templates/outerDescribe.handlebars
+++ b/templates/outerDescribe.handlebars
@@ -2,17 +2,7 @@
 var chai = require('chai');{{#if importValidator}}
 var ZSchema = require('z-schema');
 
-ZSchema.registerFormat("int32", function (str) {
-return !isNaN(str);
-});
-var validator = new ZSchema({});
-ZSchema.registerFormat("int64", function (str) {
-return !isNaN(str);
-});
-ZSchema.registerFormat("double", function (str) {
-return !isNaN(str);
-});
-
+require('./custom-formats')(ZSchema);
 var validator = new ZSchema({});{{/if}}
 {{#is testmodule 'request'}}
 var request = require('request');

--- a/test/custom-formats/schema.json
+++ b/test/custom-formats/schema.json
@@ -1,0 +1,29 @@
+{
+  "type": "object",
+  "properties": {
+    "id32": {
+      "type": "integer",
+      "format": "int32"
+    },
+    "id64": {
+      "type": "integer",
+      "format": "int64"
+    },
+    "idDouble": {
+      "type": "integer",
+      "format": "double"
+    },
+    "float": {
+      "type": "integer",
+      "format": "float"
+    },
+    "dateRegister": {
+      "type": "string",
+      "format": "date"
+    },
+    "password": {
+      "type": "string",
+      "format": "password"
+    }
+  }
+}

--- a/test/custom-formats/test.js
+++ b/test/custom-formats/test.js
@@ -1,0 +1,23 @@
+'use strict';
+var path = require('path');
+var assert = require('chai').assert;
+var ZSchema = require('z-schema');
+
+require(path.join(process.cwd(), './custom-formats'))(ZSchema);
+var validator = new ZSchema({});
+var schema = require('./schema.json');
+
+describe('When using swagger custom formats ', function() {
+  var json = {
+    id32: 123456789,
+    id64: 2345762897,
+    idDouble: 349857394857,
+    float: 987987,
+    dateRegister: '2011-10-10T14:48:00'
+  };
+
+  it('should validate the json against the schema', function() {
+    assert.isTrue(validator.validate(json, schema));
+  });
+
+});

--- a/test/loadTest/compare/request/assert/base-path-test.js
+++ b/test/loadTest/compare/request/assert/base-path-test.js
@@ -1,6 +1,8 @@
 'use strict';
 var chai = require('chai');
 var ZSchema = require('z-schema');
+
+require('./custom-formats')(ZSchema);
 var validator = new ZSchema({});
 var request = require('request');
 var assert = chai.assert;

--- a/test/loadTest/compare/request/expect/base-path-test.js
+++ b/test/loadTest/compare/request/expect/base-path-test.js
@@ -1,6 +1,8 @@
 'use strict';
 var chai = require('chai');
 var ZSchema = require('z-schema');
+
+require('./custom-formats')(ZSchema);
 var validator = new ZSchema({});
 var request = require('request');
 var expect = chai.expect;

--- a/test/loadTest/compare/request/should/base-path-test.js
+++ b/test/loadTest/compare/request/should/base-path-test.js
@@ -1,6 +1,8 @@
 'use strict';
 var chai = require('chai');
 var ZSchema = require('z-schema');
+
+require('./custom-formats')(ZSchema);
 var validator = new ZSchema({});
 var request = require('request');
 

--- a/test/loadTest/compare/supertest/assert/base-path-test.js
+++ b/test/loadTest/compare/supertest/assert/base-path-test.js
@@ -1,6 +1,8 @@
 'use strict';
 var chai = require('chai');
 var ZSchema = require('z-schema');
+
+require('./custom-formats')(ZSchema);
 var validator = new ZSchema({});
 var supertest = require('supertest');
 var api = supertest('https://api.uber.com'); // supertest init;

--- a/test/loadTest/compare/supertest/expect/base-path-test.js
+++ b/test/loadTest/compare/supertest/expect/base-path-test.js
@@ -1,6 +1,8 @@
 'use strict';
 var chai = require('chai');
 var ZSchema = require('z-schema');
+
+require('./custom-formats')(ZSchema);
 var validator = new ZSchema({});
 var supertest = require('supertest');
 var api = supertest('https://api.uber.com'); // supertest init;

--- a/test/loadTest/compare/supertest/should/base-path-test.js
+++ b/test/loadTest/compare/supertest/should/base-path-test.js
@@ -1,6 +1,8 @@
 'use strict';
 var chai = require('chai');
 var ZSchema = require('z-schema');
+
+require('./custom-formats')(ZSchema);
 var validator = new ZSchema({});
 var supertest = require('supertest');
 var api = supertest('https://api.uber.com'); // supertest init;

--- a/test/robust/compare/request/assert/base-path-test.js
+++ b/test/robust/compare/request/assert/base-path-test.js
@@ -1,6 +1,8 @@
 'use strict';
 var chai = require('chai');
 var ZSchema = require('z-schema');
+
+require('./custom-formats')(ZSchema);
 var validator = new ZSchema({});
 var request = require('request');
 var assert = chai.assert;

--- a/test/robust/compare/request/expect/base-path-test.js
+++ b/test/robust/compare/request/expect/base-path-test.js
@@ -1,6 +1,8 @@
 'use strict';
 var chai = require('chai');
 var ZSchema = require('z-schema');
+
+require('./custom-formats')(ZSchema);
 var validator = new ZSchema({});
 var request = require('request');
 var expect = chai.expect;

--- a/test/robust/compare/request/should/base-path-test.js
+++ b/test/robust/compare/request/should/base-path-test.js
@@ -1,6 +1,8 @@
 'use strict';
 var chai = require('chai');
 var ZSchema = require('z-schema');
+
+require('./custom-formats')(ZSchema);
 var validator = new ZSchema({});
 var request = require('request');
 

--- a/test/robust/compare/supertest/assert/base-path-test.js
+++ b/test/robust/compare/supertest/assert/base-path-test.js
@@ -1,6 +1,8 @@
 'use strict';
 var chai = require('chai');
 var ZSchema = require('z-schema');
+
+require('./custom-formats')(ZSchema);
 var validator = new ZSchema({});
 var supertest = require('supertest');
 var api = supertest('https://api.uber.com'); // supertest init;

--- a/test/robust/compare/supertest/expect/base-path-test.js
+++ b/test/robust/compare/supertest/expect/base-path-test.js
@@ -1,6 +1,8 @@
 'use strict';
 var chai = require('chai');
 var ZSchema = require('z-schema');
+
+require('./custom-formats')(ZSchema);
 var validator = new ZSchema({});
 var supertest = require('supertest');
 var api = supertest('https://api.uber.com'); // supertest init;

--- a/test/robust/compare/supertest/should/base-path-test.js
+++ b/test/robust/compare/supertest/should/base-path-test.js
@@ -1,6 +1,8 @@
 'use strict';
 var chai = require('chai');
 var ZSchema = require('z-schema');
+
+require('./custom-formats')(ZSchema);
 var validator = new ZSchema({});
 var supertest = require('supertest');
 var api = supertest('https://api.uber.com'); // supertest init;


### PR DESCRIPTION
Added some current swagger schema types to the Z-schema validator, with some base validation as well. This can be more complete but I ran out of time. 

It is partly based on the ideas of #99, but with added testing. #99 can be closed if this one is merged as well