### PR TITLE
update travis node versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: node_js
 node_js:
-  - '0.10'
   - '0.12'
-  - 'iojs'
+  - '4.4.5'


### PR DESCRIPTION
removed old nodejs and iojs, which ahd merged back to node, and added 4.4.5
Solves #109 