### PR TITLE
added option to generate tests only for defined status codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ stt.testGen(swagger, config);
 * **`assertionFormat`** *required*: One of `should`, `expect` or `assert`. Choose which assertion method should be used in output test code.
 * **`testModule`** *required*: One of `supertest` or `request`. Choose between direct API calls (`request`) vs. programatic access to your API (`supertest`).
 * **`pathNames`** *required*: List of path names available in your Swagger API spec used to generate tests for. Empty array leads to **all paths**.
+* **`statusCodes`** *optional* Array with status codes to generate tests for. Useful for generating only happy-flow tests. Excluding this param will generate tests for all responses.
 * **`loadTest`** *optional*: List of objects info in your Swagger API spec used to generate stress tests. If specify, pathName & operation are **required**. Optional fields requests defaults to `1000`, concurrent defaults to `100`.
 * **`maxLen`** *optional*: Maximum line length. Defaults to `80`.
 * **`pathParams`** *optional*: Object containing the values of a specific path parameters.

--- a/index.js
+++ b/index.js
@@ -294,7 +294,17 @@ function testGenContentTypes(swagger, path, operation, res, config, info) {
  * @returns {string|Array} set of all tests for a path's operation
  */
 function testGenOperation(swagger, path, operation, config, info) {
+
   var responses = swagger.paths[path][operation].responses;
+
+  // filter out the wanted codes
+  if (config.statusCodes) {
+    responses = {};
+    config.statusCodes.forEach(function(code) {
+      responses[code] = swagger.paths[path][operation].responses[code];
+    });
+  }
+
   var result = [];
   var source;
   var innerDescribeFn;

--- a/test/statuscode-generation/compare/request/base-path-test.js
+++ b/test/statuscode-generation/compare/request/base-path-test.js
@@ -1,0 +1,29 @@
+'use strict';
+var chai = require('chai');
+var request = require('request');
+
+chai.should();
+
+describe('/', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      request({
+        url: 'http://basic.herokuapp.com/',
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      },
+      function(error, res, body) {
+        if (error) return done(error);
+
+        res.statusCode.should.equal(200);
+
+        body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/statuscode-generation/swagger.json
+++ b/test/statuscode-generation/swagger.json
@@ -1,0 +1,29 @@
+{
+    "swagger": "2.0",
+    "info": {
+        "version": "0.0.0",
+        "title": "Simple API"
+    },
+  "host": "basic.herokuapp.com",
+    "paths": {
+        "/": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    },
+                    "400": {
+                      "description": "NOK"
+                    },
+                    "404": {
+                      "description": "not found"
+                    },
+                    "500": {
+                      "description": "very bad things happening"
+                    }
+                }
+            }
+
+        }
+    }
+}

--- a/test/statuscode-generation/test.js
+++ b/test/statuscode-generation/test.js
@@ -1,0 +1,76 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Apigee Corporation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+
+/**
+ * This files tests is the user can set the template location
+ */
+'use strict';
+
+var assert = require('chai').assert;
+var testGen = require('../../index.js').testGen;
+var swagger = require('./swagger.json');
+var yaml = require('js-yaml');
+var join = require('path').join;
+var rules;
+
+var fs = require('fs');
+
+rules = yaml.safeLoad(fs.readFileSync(join(__dirname,
+  '/../../.eslintrc'), 'utf8'));
+rules.env = {mocha: true};
+
+describe('UserDefined status codes', function() {
+  var output = testGen(swagger, {
+    assertionFormat: 'should',
+    pathNames: [],
+    testModule: 'request',
+    statusCodes: [200]
+
+  });
+
+  it('should only generate code for the supplied codes', function() {
+
+    var paths1 = [];
+    var ndx;
+
+    for (ndx in output) {
+      if (output) {
+        paths1.push(join(__dirname, '/compare/request/' + output[ndx].name));
+      }
+    }
+
+    assert.isArray(output);
+    assert.lengthOf(output, 1);
+
+    var generatedCode;
+
+    for (ndx in paths1) {
+      if (paths1 !== undefined) {
+        generatedCode = fs.readFileSync(paths1[ndx], 'utf8');
+        assert.equal(output[ndx].test, generatedCode);
+      }
+    }
+  });
+});


### PR DESCRIPTION
This functionality gives the option to only generate happy flow tests, or 404 tests. This makes it easier to supply mock data. See also #107 