### PR TITLE
Fix to create path includes backslashes on windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -90,7 +90,7 @@ function getData(swagger, apiPath, operation, response, config, info) {
   }
 
   // used for checking requestData table
-  var requestPath = (swagger.basePath) ? path.join(swagger.basePath, apiPath) : apiPath;
+  var requestPath = (swagger.basePath) ? path.posix.join(swagger.basePath, apiPath) : apiPath;
 
 
   // cope with loadTest info


### PR DESCRIPTION
This PR provides to avoid to generate path to includes backslashes.

On Windows, path.join() use backslashes as separate character.
So the test case that generated by this module occurs error, because request api includes backslashes not slash.
If use path.posix.join(), always use slash.

And, I think this PR can resolve #125.
