### PR TITLE
Proposing update for parsing Float

### DIFF
--- a/custom-formats.js
+++ b/custom-formats.js
@@ -22,7 +22,7 @@ module.exports = function(zSchema) {
 
   zSchema.registerFormat('float', function(val) {
     // better parsing for custom "float" format
-    if(Number.parseFloat(val)){
+    if (Number.parseFloat(val)) {
       return true;
     } else {
       return false;

--- a/test/loadTest/compare/request/assert/base-path-test.js
+++ b/test/loadTest/compare/request/assert/base-path-test.js
@@ -24,8 +24,12 @@ var customFormats = module.exports = function(zSchema) {
   });
 
   zSchema.registerFormat('float', function(val) {
-    // should parse
-    return Number.isInteger(val);
+    // better parsing for custom "float" format
+    if (Number.parseFloat(val)) {
+      return true;
+    } else {
+      return false;
+    }
   });
 
   zSchema.registerFormat('date', function(val) {

--- a/test/loadTest/compare/request/expect/base-path-test.js
+++ b/test/loadTest/compare/request/expect/base-path-test.js
@@ -24,8 +24,12 @@ var customFormats = module.exports = function(zSchema) {
   });
 
   zSchema.registerFormat('float', function(val) {
-    // should parse
-    return Number.isInteger(val);
+    // better parsing for custom "float" format
+    if (Number.parseFloat(val)) {
+      return true;
+    } else {
+      return false;
+    }
   });
 
   zSchema.registerFormat('date', function(val) {

--- a/test/loadTest/compare/request/should/base-path-test.js
+++ b/test/loadTest/compare/request/should/base-path-test.js
@@ -24,8 +24,12 @@ var customFormats = module.exports = function(zSchema) {
   });
 
   zSchema.registerFormat('float', function(val) {
-    // should parse
-    return Number.isInteger(val);
+    // better parsing for custom "float" format
+    if (Number.parseFloat(val)) {
+      return true;
+    } else {
+      return false;
+    }
   });
 
   zSchema.registerFormat('date', function(val) {

--- a/test/loadTest/compare/supertest/assert/base-path-test.js
+++ b/test/loadTest/compare/supertest/assert/base-path-test.js
@@ -24,8 +24,12 @@ var customFormats = module.exports = function(zSchema) {
   });
 
   zSchema.registerFormat('float', function(val) {
-    // should parse
-    return Number.isInteger(val);
+    // better parsing for custom "float" format
+    if (Number.parseFloat(val)) {
+      return true;
+    } else {
+      return false;
+    }
   });
 
   zSchema.registerFormat('date', function(val) {

--- a/test/loadTest/compare/supertest/expect/base-path-test.js
+++ b/test/loadTest/compare/supertest/expect/base-path-test.js
@@ -24,8 +24,12 @@ var customFormats = module.exports = function(zSchema) {
   });
 
   zSchema.registerFormat('float', function(val) {
-    // should parse
-    return Number.isInteger(val);
+    // better parsing for custom "float" format
+    if (Number.parseFloat(val)) {
+      return true;
+    } else {
+      return false;
+    }
   });
 
   zSchema.registerFormat('date', function(val) {

--- a/test/loadTest/compare/supertest/should/base-path-test.js
+++ b/test/loadTest/compare/supertest/should/base-path-test.js
@@ -24,8 +24,12 @@ var customFormats = module.exports = function(zSchema) {
   });
 
   zSchema.registerFormat('float', function(val) {
-    // should parse
-    return Number.isInteger(val);
+    // better parsing for custom "float" format
+    if (Number.parseFloat(val)) {
+      return true;
+    } else {
+      return false;
+    }
   });
 
   zSchema.registerFormat('date', function(val) {

--- a/test/robust/compare/request/assert/base-path-test.js
+++ b/test/robust/compare/request/assert/base-path-test.js
@@ -24,8 +24,12 @@ var customFormats = module.exports = function(zSchema) {
   });
 
   zSchema.registerFormat('float', function(val) {
-    // should parse
-    return Number.isInteger(val);
+    // better parsing for custom "float" format
+    if (Number.parseFloat(val)) {
+      return true;
+    } else {
+      return false;
+    }
   });
 
   zSchema.registerFormat('date', function(val) {

--- a/test/robust/compare/request/expect/base-path-test.js
+++ b/test/robust/compare/request/expect/base-path-test.js
@@ -24,8 +24,12 @@ var customFormats = module.exports = function(zSchema) {
   });
 
   zSchema.registerFormat('float', function(val) {
-    // should parse
-    return Number.isInteger(val);
+    // better parsing for custom "float" format
+    if (Number.parseFloat(val)) {
+      return true;
+    } else {
+      return false;
+    }
   });
 
   zSchema.registerFormat('date', function(val) {

--- a/test/robust/compare/request/should/base-path-test.js
+++ b/test/robust/compare/request/should/base-path-test.js
@@ -24,8 +24,12 @@ var customFormats = module.exports = function(zSchema) {
   });
 
   zSchema.registerFormat('float', function(val) {
-    // should parse
-    return Number.isInteger(val);
+    // better parsing for custom "float" format
+    if (Number.parseFloat(val)) {
+      return true;
+    } else {
+      return false;
+    }
   });
 
   zSchema.registerFormat('date', function(val) {

--- a/test/robust/compare/supertest/assert/base-path-test.js
+++ b/test/robust/compare/supertest/assert/base-path-test.js
@@ -24,8 +24,12 @@ var customFormats = module.exports = function(zSchema) {
   });
 
   zSchema.registerFormat('float', function(val) {
-    // should parse
-    return Number.isInteger(val);
+    // better parsing for custom "float" format
+    if (Number.parseFloat(val)) {
+      return true;
+    } else {
+      return false;
+    }
   });
 
   zSchema.registerFormat('date', function(val) {

--- a/test/robust/compare/supertest/expect/base-path-test.js
+++ b/test/robust/compare/supertest/expect/base-path-test.js
@@ -24,8 +24,12 @@ var customFormats = module.exports = function(zSchema) {
   });
 
   zSchema.registerFormat('float', function(val) {
-    // should parse
-    return Number.isInteger(val);
+    // better parsing for custom "float" format
+    if (Number.parseFloat(val)) {
+      return true;
+    } else {
+      return false;
+    }
   });
 
   zSchema.registerFormat('date', function(val) {

--- a/test/robust/compare/supertest/should/base-path-test.js
+++ b/test/robust/compare/supertest/should/base-path-test.js
@@ -24,8 +24,12 @@ var customFormats = module.exports = function(zSchema) {
   });
 
   zSchema.registerFormat('float', function(val) {
-    // should parse
-    return Number.isInteger(val);
+    // better parsing for custom "float" format
+    if (Number.parseFloat(val)) {
+      return true;
+    } else {
+      return false;
+    }
   });
 
   zSchema.registerFormat('date', function(val) {


### PR DESCRIPTION
Number.isInteger(1.2) return false, which causes validation logic to break. Proposing to use Number.parseFloat()