### PR TITLE
change request-data use raw path w/o basepath

### DIFF
--- a/index.js
+++ b/index.js
@@ -201,10 +201,10 @@ function getData(swagger, apiPath, operation, response, config, info) {
 
   // get requestData from config if defined for this path:operation:response
   if (config.requestData &&
-    config.requestData[requestPath] &&
-    config.requestData[requestPath][operation] &&
-    config.requestData[requestPath][operation][response]) {
-    data.requestData = config.requestData[requestPath][operation][response];
+    config.requestData[apiPath] &&
+    config.requestData[apiPath][operation] &&
+    config.requestData[apiPath][operation][response]) {
+    data.requestData = config.requestData[apiPath][operation][response];
     // if we have requestData, fill the path params accordingly
     var mockParameters = {};
 

--- a/test/request-data/compare/request/expect/qs1-user-test.js
+++ b/test/request-data/compare/request/expect/qs1-user-test.js
@@ -7,7 +7,7 @@ describe('/user', function() {
   describe('post', function() {
     it('should respond with 200 OK and some description', function(done) {
       request({
-        url: 'https://api.uber.com/user',
+        url: 'https://api.uber.com/v1/user',
         json: true,
         qs: {
           longitude: 10
@@ -30,7 +30,7 @@ describe('/user', function() {
 
     it('should respond with 400 NOT OK', function(done) {
       request({
-        url: 'https://api.uber.com/user',
+        url: 'https://api.uber.com/v1/user',
         json: true,
         qs: {
           longitude: 'DATA GOES HERE'
@@ -55,7 +55,7 @@ describe('/user', function() {
 
     it('should respond with 500 SERVER ERROR', function(done) {
       request({
-        url: 'https://api.uber.com/user',
+        url: 'https://api.uber.com/v1/user',
         json: true,
         qs: {
           longitude: 'DATA GOES HERE'

--- a/test/request-data/compare/request/expect/user-test.js
+++ b/test/request-data/compare/request/expect/user-test.js
@@ -7,7 +7,7 @@ describe('/user', function() {
   describe('post', function() {
     it('should respond with 200 OK and some description', function(done) {
       request({
-        url: 'https://api.uber.com/user',
+        url: 'https://api.uber.com/v1/user',
         json: true,
         qs: {
           longitude: 'DATA GOES HERE'
@@ -30,7 +30,7 @@ describe('/user', function() {
 
     it('should respond with 400 NOT OK', function(done) {
       request({
-        url: 'https://api.uber.com/user',
+        url: 'https://api.uber.com/v1/user',
         json: true,
         qs: {
           longitude: 'DATA GOES HERE'
@@ -55,7 +55,7 @@ describe('/user', function() {
 
     it('should respond with 500 SERVER ERROR', function(done) {
       request({
-        url: 'https://api.uber.com/user',
+        url: 'https://api.uber.com/v1/user',
         json: true,
         qs: {
           longitude: 'DATA GOES HERE'

--- a/test/request-data/swagger-post.json
+++ b/test/request-data/swagger-post.json
@@ -8,6 +8,7 @@
     "schemes": [
         "https"
     ],
+    "basePath":"/v1",
     "paths": {
         "/user": {
             "post": {


### PR DESCRIPTION
Fix #150 

Request data resolution uses raw API path without the base path prepended.

@baynezy can you take a look at this? its an XS change