### PR TITLE
Issue 163 fix for arete report typo

### DIFF
--- a/templates/request/get/get.handlebars
+++ b/templates/request/get/get.handlebars
@@ -110,7 +110,7 @@
           {{#is assertion 'expect'}}
           expect(report.successfulResponses.length).
           to.equal(report.results.length);
-          expect(report.averageResponseTimeInternal).
+          expect(report.averageResponseTimeInterval).
           to.be.lessThan('TIME DATA HERE');
           expect(report.timeElapsed).
           to.be.lessThan('TIME DATA HERE');
@@ -118,7 +118,7 @@
           {{#is assertion 'should'}}
           report.successfulResponses.length.
           should.equal(report.results.length);
-          (report.averageResponseTimeInternal).
+          (report.averageResponseTimeInterval).
           should.be.lessThan('TIME DATA HERE');
           (report.timeElapsed).
           should.be.lessThan('TIME DATA HERE');
@@ -126,7 +126,7 @@
           {{#is assertion 'assert'}}
           assert.equal(report.successfulResponses.length,
           report.results.length);
-          assert.isBelow(report.averageResponseTimeInternal,
+          assert.isBelow(report.averageResponseTimeInterval,
           'TIME DATA HERE');
           assert.isBelow(report.timeElapsed,
           'TIME DATA HERE');

--- a/templates/request/patch/patch.handlebars
+++ b/templates/request/patch/patch.handlebars
@@ -166,7 +166,7 @@
           {{#is assertion 'expect'}}
           expect(report.successfulResponses.length).
           to.equal(report.results.length);
-          expect(report.averageResponseTimeInternal).
+          expect(report.averageResponseTimeInterval).
           to.be.lessThan('TIME DATA HERE');
           expect(report.timeElapsed).
           to.be.lessThan('TIME DATA HERE');
@@ -174,7 +174,7 @@
           {{#is assertion 'should'}}
           report.successfulResponses.length.
           should.equal(report.results.length);
-          (report.averageResponseTimeInternal).
+          (report.averageResponseTimeInterval).
           should.be.lessThan('TIME DATA HERE');
           (report.timeElapsed).
           should.be.lessThan('TIME DATA HERE');
@@ -182,7 +182,7 @@
           {{#is assertion 'assert'}}
           assert.equal(report.successfulResponses.length,
           report.results.length);
-          assert.isBelow(report.averageResponseTimeInternal,
+          assert.isBelow(report.averageResponseTimeInterval,
           'TIME DATA HERE');
           assert.isBelow(report.timeElapsed,
           'TIME DATA HERE');

--- a/templates/request/post/post.handlebars
+++ b/templates/request/post/post.handlebars
@@ -164,7 +164,7 @@
           {{#is assertion 'expect'}}
           expect(report.successfulResponses.length).
           to.equal(report.results.length);
-          expect(report.averageResponseTimeInternal).
+          expect(report.averageResponseTimeInterval).
           to.be.lessThan('TIME DATA HERE');
           expect(report.timeElapsed).
           to.be.lessThan('TIME DATA HERE');
@@ -172,7 +172,7 @@
           {{#is assertion 'should'}}
           report.successfulResponses.length.
           should.equal(report.results.length);
-          (report.averageResponseTimeInternal).
+          (report.averageResponseTimeInterval).
           should.be.lessThan('TIME DATA HERE');
           (report.timeElapsed).
           should.be.lessThan('TIME DATA HERE');
@@ -180,7 +180,7 @@
           {{#is assertion 'assert'}}
           assert.equal(report.successfulResponses.length,
           report.results.length);
-          assert.isBelow(report.averageResponseTimeInternal,
+          assert.isBelow(report.averageResponseTimeInterval,
           'TIME DATA HERE');
           assert.isBelow(report.timeElapsed,
           'TIME DATA HERE');

--- a/templates/request/put/put.handlebars
+++ b/templates/request/put/put.handlebars
@@ -164,7 +164,7 @@
           {{#is assertion 'expect'}}
           expect(report.successfulResponses.length).
           to.equal(report.results.length);
-          expect(report.averageResponseTimeInternal).
+          expect(report.averageResponseTimeInterval).
           to.be.lessThan('TIME DATA HERE');
           expect(report.timeElapsed).
           to.be.lessThan('TIME DATA HERE');
@@ -172,7 +172,7 @@
           {{#is assertion 'should'}}
           report.successfulResponses.length.
           should.equal(report.results.length);
-          (report.averageResponseTimeInternal).
+          (report.averageResponseTimeInterval).
           should.be.lessThan('TIME DATA HERE');
           (report.timeElapsed).
           should.be.lessThan('TIME DATA HERE');
@@ -180,7 +180,7 @@
           {{#is assertion 'assert'}}
           assert.equal(report.successfulResponses.length,
           report.results.length);
-          assert.isBelow(report.averageResponseTimeInternal,
+          assert.isBelow(report.averageResponseTimeInterval,
           'TIME DATA HERE');
           assert.isBelow(report.timeElapsed,
           'TIME DATA HERE');

--- a/templates/supertest/get/get.handlebars
+++ b/templates/supertest/get/get.handlebars
@@ -106,7 +106,7 @@
           {{#is assertion 'expect'}}
           expect(report.successfulResponses.length).
           to.equal(report.results.length);
-          expect(report.averageResponseTimeInternal).
+          expect(report.averageResponseTimeInterval).
           to.be.lessThan('TIME DATA HERE');
           expect(report.timeElapsed).
           to.be.lessThan('TIME DATA HERE');
@@ -114,7 +114,7 @@
           {{#is assertion 'should'}}
           report.successfulResponses.length.
           should.equal(report.results.length);
-          (report.averageResponseTimeInternal).
+          (report.averageResponseTimeInterval).
           should.be.lessThan('TIME DATA HERE');
           (report.timeElapsed).
           should.be.lessThan('TIME DATA HERE');
@@ -122,7 +122,7 @@
           {{#is assertion 'assert'}}
           assert.equal(report.successfulResponses.length,
           report.results.length);
-          assert.isBelow(report.averageResponseTimeInternal,
+          assert.isBelow(report.averageResponseTimeInterval,
           'TIME DATA HERE');
           assert.isBelow(report.timeElapsed,
           'TIME DATA HERE');

--- a/templates/supertest/options/options.handlebars
+++ b/templates/supertest/options/options.handlebars
@@ -106,7 +106,7 @@
           {{#is assertion 'expect'}}
           expect(report.successfulResponses.length).
           to.equal(report.results.length);
-          expect(report.averageResponseTimeInternal).
+          expect(report.averageResponseTimeInterval).
           to.be.lessThan('TIME DATA HERE');
           expect(report.timeElapsed).
           to.be.lessThan('TIME DATA HERE');
@@ -114,7 +114,7 @@
           {{#is assertion 'should'}}
           report.successfulResponses.length.
           should.equal(report.results.length);
-          (report.averageResponseTimeInternal).
+          (report.averageResponseTimeInterval).
           should.be.lessThan('TIME DATA HERE');
           (report.timeElapsed).
           should.be.lessThan('TIME DATA HERE');
@@ -122,7 +122,7 @@
           {{#is assertion 'assert'}}
           assert.equal(report.successfulResponses.length,
           report.results.length);
-          assert.isBelow(report.averageResponseTimeInternal,
+          assert.isBelow(report.averageResponseTimeInterval,
           'TIME DATA HERE');
           assert.isBelow(report.timeElapsed,
           'TIME DATA HERE');

--- a/templates/supertest/patch/patch.handlebars
+++ b/templates/supertest/patch/patch.handlebars
@@ -151,7 +151,7 @@
           {{#is assertion 'expect'}}
           expect(report.successfulResponses.length).
           to.equal(report.results.length);
-          expect(report.averageResponseTimeInternal).
+          expect(report.averageResponseTimeInterval).
           to.be.lessThan('TIME DATA HERE');
           expect(report.timeElapsed).
           to.be.lessThan('TIME DATA HERE');
@@ -159,7 +159,7 @@
           {{#is assertion 'should'}}
           report.successfulResponses.length.
           should.equal(report.results.length);
-          (report.averageResponseTimeInternal).
+          (report.averageResponseTimeInterval).
           should.be.lessThan('TIME DATA HERE');
           (report.timeElapsed).
           should.be.lessThan('TIME DATA HERE');
@@ -167,7 +167,7 @@
           {{#is assertion 'assert'}}
           assert.equal(report.successfulResponses.length,
           report.results.length);
-          assert.isBelow(report.averageResponseTimeInternal,
+          assert.isBelow(report.averageResponseTimeInterval,
           'TIME DATA HERE');
           assert.isBelow(report.timeElapsed,
           'TIME DATA HERE');

--- a/templates/supertest/post/post.handlebars
+++ b/templates/supertest/post/post.handlebars
@@ -150,7 +150,7 @@
           {{#is assertion 'expect'}}
           expect(report.successfulResponses.length).
           to.equal(report.results.length);
-          expect(report.averageResponseTimeInternal).
+          expect(report.averageResponseTimeInterval).
           to.be.lessThan('TIME DATA HERE');
           expect(report.timeElapsed).
           to.be.lessThan('TIME DATA HERE');
@@ -158,7 +158,7 @@
           {{#is assertion 'should'}}
           report.successfulResponses.length.
           should.equal(report.results.length);
-          (report.averageResponseTimeInternal).
+          (report.averageResponseTimeInterval).
           should.be.lessThan('TIME DATA HERE');
           (report.timeElapsed).
           should.be.lessThan('TIME DATA HERE');
@@ -166,7 +166,7 @@
           {{#is assertion 'assert'}}
           assert.equal(report.successfulResponses.length,
           report.results.length);
-          assert.isBelow(report.averageResponseTimeInternal,
+          assert.isBelow(report.averageResponseTimeInterval,
           'TIME DATA HERE');
           assert.isBelow(report.timeElapsed,
           'TIME DATA HERE');

--- a/templates/supertest/put/put.handlebars
+++ b/templates/supertest/put/put.handlebars
@@ -150,7 +150,7 @@
           {{#is assertion 'expect'}}
           expect(report.successfulResponses.length).
           to.equal(report.results.length);
-          expect(report.averageResponseTimeInternal).
+          expect(report.averageResponseTimeInterval).
           to.be.lessThan('TIME DATA HERE');
           expect(report.timeElapsed).
           to.be.lessThan('TIME DATA HERE');
@@ -158,7 +158,7 @@
           {{#is assertion 'should'}}
           report.successfulResponses.length.
           should.equal(report.results.length);
-          (report.averageResponseTimeInternal).
+          (report.averageResponseTimeInterval).
           should.be.lessThan('TIME DATA HERE');
           (report.timeElapsed).
           should.be.lessThan('TIME DATA HERE');
@@ -166,7 +166,7 @@
           {{#is assertion 'assert'}}
           assert.equal(report.successfulResponses.length,
           report.results.length);
-          assert.isBelow(report.averageResponseTimeInternal,
+          assert.isBelow(report.averageResponseTimeInterval,
           'TIME DATA HERE');
           assert.isBelow(report.timeElapsed,
           'TIME DATA HERE');

--- a/test/loadTest/compare/request/assert/user-test.js
+++ b/test/loadTest/compare/request/assert/user-test.js
@@ -53,7 +53,7 @@ describe('/user', function() {
 
           assert.equal(report.successfulResponses.length,
           report.results.length);
-          assert.isBelow(report.averageResponseTimeInternal,
+          assert.isBelow(report.averageResponseTimeInterval,
           'TIME DATA HERE');
           assert.isBelow(report.timeElapsed,
           'TIME DATA HERE');
@@ -107,7 +107,7 @@ describe('/user', function() {
 
           assert.equal(report.successfulResponses.length,
           report.results.length);
-          assert.isBelow(report.averageResponseTimeInternal,
+          assert.isBelow(report.averageResponseTimeInterval,
           'TIME DATA HERE');
           assert.isBelow(report.timeElapsed,
           'TIME DATA HERE');
@@ -161,7 +161,7 @@ describe('/user', function() {
 
           assert.equal(report.successfulResponses.length,
           report.results.length);
-          assert.isBelow(report.averageResponseTimeInternal,
+          assert.isBelow(report.averageResponseTimeInterval,
           'TIME DATA HERE');
           assert.isBelow(report.timeElapsed,
           'TIME DATA HERE');
@@ -311,7 +311,7 @@ describe('/user', function() {
 
           assert.equal(report.successfulResponses.length,
           report.results.length);
-          assert.isBelow(report.averageResponseTimeInternal,
+          assert.isBelow(report.averageResponseTimeInterval,
           'TIME DATA HERE');
           assert.isBelow(report.timeElapsed,
           'TIME DATA HERE');
@@ -377,7 +377,7 @@ describe('/user', function() {
 
           assert.equal(report.successfulResponses.length,
           report.results.length);
-          assert.isBelow(report.averageResponseTimeInternal,
+          assert.isBelow(report.averageResponseTimeInterval,
           'TIME DATA HERE');
           assert.isBelow(report.timeElapsed,
           'TIME DATA HERE');
@@ -443,7 +443,7 @@ describe('/user', function() {
 
           assert.equal(report.successfulResponses.length,
           report.results.length);
-          assert.isBelow(report.averageResponseTimeInternal,
+          assert.isBelow(report.averageResponseTimeInterval,
           'TIME DATA HERE');
           assert.isBelow(report.timeElapsed,
           'TIME DATA HERE');

--- a/test/loadTest/compare/request/expect/user-test.js
+++ b/test/loadTest/compare/request/expect/user-test.js
@@ -53,7 +53,7 @@ describe('/user', function() {
 
           expect(report.successfulResponses.length).
           to.equal(report.results.length);
-          expect(report.averageResponseTimeInternal).
+          expect(report.averageResponseTimeInterval).
           to.be.lessThan('TIME DATA HERE');
           expect(report.timeElapsed).
           to.be.lessThan('TIME DATA HERE');
@@ -107,7 +107,7 @@ describe('/user', function() {
 
           expect(report.successfulResponses.length).
           to.equal(report.results.length);
-          expect(report.averageResponseTimeInternal).
+          expect(report.averageResponseTimeInterval).
           to.be.lessThan('TIME DATA HERE');
           expect(report.timeElapsed).
           to.be.lessThan('TIME DATA HERE');
@@ -161,7 +161,7 @@ describe('/user', function() {
 
           expect(report.successfulResponses.length).
           to.equal(report.results.length);
-          expect(report.averageResponseTimeInternal).
+          expect(report.averageResponseTimeInterval).
           to.be.lessThan('TIME DATA HERE');
           expect(report.timeElapsed).
           to.be.lessThan('TIME DATA HERE');

--- a/test/loadTest/compare/request/should/user-test.js
+++ b/test/loadTest/compare/request/should/user-test.js
@@ -129,7 +129,7 @@ describe('/user', function() {
 
           report.successfulResponses.length.
           should.equal(report.results.length);
-          (report.averageResponseTimeInternal).
+          (report.averageResponseTimeInterval).
           should.be.lessThan('TIME DATA HERE');
           (report.timeElapsed).
           should.be.lessThan('TIME DATA HERE');
@@ -195,7 +195,7 @@ describe('/user', function() {
 
           report.successfulResponses.length.
           should.equal(report.results.length);
-          (report.averageResponseTimeInternal).
+          (report.averageResponseTimeInterval).
           should.be.lessThan('TIME DATA HERE');
           (report.timeElapsed).
           should.be.lessThan('TIME DATA HERE');
@@ -261,7 +261,7 @@ describe('/user', function() {
 
           report.successfulResponses.length.
           should.equal(report.results.length);
-          (report.averageResponseTimeInternal).
+          (report.averageResponseTimeInterval).
           should.be.lessThan('TIME DATA HERE');
           (report.timeElapsed).
           should.be.lessThan('TIME DATA HERE');

--- a/test/loadTest/compare/supertest/assert/user-test.js
+++ b/test/loadTest/compare/supertest/assert/user-test.js
@@ -43,7 +43,7 @@ describe('/user', function() {
 
           assert.equal(report.successfulResponses.length,
           report.results.length);
-          assert.isBelow(report.averageResponseTimeInternal,
+          assert.isBelow(report.averageResponseTimeInterval,
           'TIME DATA HERE');
           assert.isBelow(report.timeElapsed,
           'TIME DATA HERE');
@@ -86,7 +86,7 @@ describe('/user', function() {
 
           assert.equal(report.successfulResponses.length,
           report.results.length);
-          assert.isBelow(report.averageResponseTimeInternal,
+          assert.isBelow(report.averageResponseTimeInterval,
           'TIME DATA HERE');
           assert.isBelow(report.timeElapsed,
           'TIME DATA HERE');
@@ -129,7 +129,7 @@ describe('/user', function() {
 
           assert.equal(report.successfulResponses.length,
           report.results.length);
-          assert.isBelow(report.averageResponseTimeInternal,
+          assert.isBelow(report.averageResponseTimeInterval,
           'TIME DATA HERE');
           assert.isBelow(report.timeElapsed,
           'TIME DATA HERE');
@@ -247,7 +247,7 @@ describe('/user', function() {
 
           assert.equal(report.successfulResponses.length,
           report.results.length);
-          assert.isBelow(report.averageResponseTimeInternal,
+          assert.isBelow(report.averageResponseTimeInterval,
           'TIME DATA HERE');
           assert.isBelow(report.timeElapsed,
           'TIME DATA HERE');
@@ -302,7 +302,7 @@ describe('/user', function() {
 
           assert.equal(report.successfulResponses.length,
           report.results.length);
-          assert.isBelow(report.averageResponseTimeInternal,
+          assert.isBelow(report.averageResponseTimeInterval,
           'TIME DATA HERE');
           assert.isBelow(report.timeElapsed,
           'TIME DATA HERE');
@@ -357,7 +357,7 @@ describe('/user', function() {
 
           assert.equal(report.successfulResponses.length,
           report.results.length);
-          assert.isBelow(report.averageResponseTimeInternal,
+          assert.isBelow(report.averageResponseTimeInterval,
           'TIME DATA HERE');
           assert.isBelow(report.timeElapsed,
           'TIME DATA HERE');

--- a/test/loadTest/compare/supertest/expect/user-test.js
+++ b/test/loadTest/compare/supertest/expect/user-test.js
@@ -43,7 +43,7 @@ describe('/user', function() {
 
           expect(report.successfulResponses.length).
           to.equal(report.results.length);
-          expect(report.averageResponseTimeInternal).
+          expect(report.averageResponseTimeInterval).
           to.be.lessThan('TIME DATA HERE');
           expect(report.timeElapsed).
           to.be.lessThan('TIME DATA HERE');
@@ -86,7 +86,7 @@ describe('/user', function() {
 
           expect(report.successfulResponses.length).
           to.equal(report.results.length);
-          expect(report.averageResponseTimeInternal).
+          expect(report.averageResponseTimeInterval).
           to.be.lessThan('TIME DATA HERE');
           expect(report.timeElapsed).
           to.be.lessThan('TIME DATA HERE');
@@ -129,7 +129,7 @@ describe('/user', function() {
 
           expect(report.successfulResponses.length).
           to.equal(report.results.length);
-          expect(report.averageResponseTimeInternal).
+          expect(report.averageResponseTimeInterval).
           to.be.lessThan('TIME DATA HERE');
           expect(report.timeElapsed).
           to.be.lessThan('TIME DATA HERE');

--- a/test/loadTest/compare/supertest/should/user-test.js
+++ b/test/loadTest/compare/supertest/should/user-test.js
@@ -98,7 +98,7 @@ describe('/user', function() {
 
           report.successfulResponses.length.
           should.equal(report.results.length);
-          (report.averageResponseTimeInternal).
+          (report.averageResponseTimeInterval).
           should.be.lessThan('TIME DATA HERE');
           (report.timeElapsed).
           should.be.lessThan('TIME DATA HERE');
@@ -153,7 +153,7 @@ describe('/user', function() {
 
           report.successfulResponses.length.
           should.equal(report.results.length);
-          (report.averageResponseTimeInternal).
+          (report.averageResponseTimeInterval).
           should.be.lessThan('TIME DATA HERE');
           (report.timeElapsed).
           should.be.lessThan('TIME DATA HERE');
@@ -208,7 +208,7 @@ describe('/user', function() {
 
           report.successfulResponses.length.
           should.equal(report.results.length);
-          (report.averageResponseTimeInternal).
+          (report.averageResponseTimeInterval).
           should.be.lessThan('TIME DATA HERE');
           (report.timeElapsed).
           should.be.lessThan('TIME DATA HERE');


### PR DESCRIPTION
Find/replace fix for #163 

The test case here is to generate a test using the Loadtest option, and ensure that running the resulting test doesn't break on 
`         expect(report.averageResponseTimeInternal).
           to.be.lessThan('TIME DATA HERE');`