### PR TITLE
Multiple request data objects; Matching config status codes to swagger spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ var tests = stt.testGen(swagger, config);
 * **`assertionFormat`** *required*: One of `should`, `expect` or `assert`. Choose which assertion method should be used in output test code.
 * **`testModule`** *required*: One of `supertest` or `request`. Choose between direct API calls (`request`) vs. programatic access to your API (`supertest`).
 * **`pathName`** *required*: List of path names available in your Swagger API spec used to generate tests for. Empty array leads to **all paths**.
-* **`statusCodes`** *optional* Array with status codes to generate tests for. Useful for generating only happy-flow tests. Excluding this param will generate tests for all responses.
+* **`statusCodes`** *optional* Array with status codes to generate tests for. Useful for generating only happy-flow tests. Excluding this param will generate tests for all responses. A test is generated for the status code only when the status code is listed in the Swagger API spec.
 * **`loadTest`** *optional*: List of objects info in your Swagger API spec used to generate stress tests. If specify, pathName & operation are **required**. Optional fields requests defaults to `1000`, concurrent defaults to `100`.
 * **`maxLen`** *optional*: Maximum line length. If set to `-1`, descriptions will not be truncated. Defaults to `80`.
 * **`pathParams`** *optional*: Object containing the values of a specific path parameters.
@@ -68,7 +68,7 @@ The mock data needs to have the following structure:
 {
    '/endpoint': {
        operation: {
-           'responseCode': [{ body: {}, description:'some description of the data']
+           'responseCode': [{ body: {}, description:'some description of the data'}]
        }
    }
  }
@@ -81,7 +81,7 @@ The mock data needs to have the following structure:
 {
    '/pet/{name}': {
        get: {
-           '200': [{ name: 'spot', description:'some description of the data']
+           '200': [{ name: 'spot', description:'some description of the data'}]
        }
    }
  }
@@ -96,7 +96,7 @@ This will make a request to `/pet?name=spot` assuming that your swagger API has 
 {
    '/pet': {
        get: {
-           '200': [{ name: 'spot', description:'some description of the data']
+           '200': [{ name: 'spot', description:'some description of the data'}]
        }
    }
  }
@@ -111,33 +111,49 @@ This will add an HTTP header `X-Token` set to `waestrydtufj` assuming that your 
 {
    '/pet': {
        get: {
-           '200': [{ 'X-Token': 'waestrydtufj', description:'some description of the data']
+           '200': [{ 'X-Token': 'waestrydtufj', description:'some description of the data'}]
        }
    }
  }
 
 ```
 
-so, for example this could be:
+Multiple objects within a status code request data array are supported. So, for example this could be:
 
 ```javascript
 {
      '/pet': {
          post: {
-             '200': [{
-               body: {
+             '200': [
+               {
+                 body: {
                   id: 1,
                   otherProperty: 'some property that is a string'
                  },
                  description: 'the description for this data'
-               }]
+               },
+               {
+                 body: {
+                  id: 2,
+                  otherProperty: 'another value of that property'
+                 },
+                 description: 'the description for another data'
+               }
+             ]
          },
          get: {
-            '200': [ {
-              guid: 'some_string_to_place_in_path',
-              anotherPathParam: 100,
-              description: 'valid path or query parameters'
-            }]
+            '200': [
+              {
+                guid: 'some_string_to_place_in_path',
+                anotherPathParam: 100,
+                description: 'valid path or query parameters'
+              },
+              {
+                guid: 'some_other_string_to_place_in_path',
+                anotherPathParam: 200,
+                description: 'another valid path or query parameters'
+              }
+          ]
          }
      }
  }
@@ -146,6 +162,8 @@ so, for example this could be:
 Note: for get-requests matching data will be transferred to the pathParams. So setting config.pathParams directly will have the same effect (see above).
 
 Every mockData item in the `responseCode` array will be used to generate a test. The description will be added to the "it" function for reference.
+
+Parameters explicitly marked as `required: false` in your Swagger API spec, will only be set if there is a matching value in requestData object. Required parameters and parameters without explicitly set `required` flag in Swagger API spec will be set to either a matching value in requestData object or 'DATA GOES HERE' string.
 
 ## License
 

--- a/index.js
+++ b/index.js
@@ -308,6 +308,7 @@ function testGenResponse(swagger, apiPath, operation, response, config, consume,
   if (data.requestData && data.requestData.length > 0) {
     result = '';
     for (var i = 0; i < data.requestData.length; i++) {
+      data.requestParameters = {};
       data = setPathParamsFromArray(data, config, i);
       data.request = JSON.stringify(data.requestData[i].body);
 

--- a/index.js
+++ b/index.js
@@ -182,7 +182,7 @@ function getData(swagger, apiPath, operation, response, config, info) {
     });
   }
 
-  if (grandProperty.responses[response].hasOwnProperty('schema')) {
+  if (grandProperty.responses[response] && grandProperty.responses[response].hasOwnProperty('schema')) {
     data.noSchema = false;
     data.schema = grandProperty.responses[response].schema;
     data.schema = JSON.stringify(data.schema, null, 2);
@@ -220,6 +220,32 @@ function getData(swagger, apiPath, operation, response, config, info) {
       data.pathParams = mockParameters;
     }
   }
+  return data;
+}
+
+/**
+* Populate path params from request data array
+* @private
+* @param  {json} data Generated Data
+* @param  {json} config configuration for testGen
+* @param  {int} idx Index of request for response
+* @returns {json} return all the properties information
+*/
+function setPathParamsFromArray(data, config, idx) {
+  // only write parameters if they are not already defined in config
+  if (data.requestData === undefined || config.pathParams) {
+    return data;
+  }
+  // if we have requestData, fill the path params accordingly
+  var mockParameters = {};
+
+  data.pathParameters.forEach(function(parameter) {
+    // find the mock data for this parameter name
+    mockParameters[parameter.name] = data.requestData.filter(function(mock) {
+      return mock.hasOwnProperty(parameter.name);
+    })[idx][parameter.name];
+  });
+  data.pathParams = mockParameters;
   return data;
 }
 
@@ -265,6 +291,7 @@ function testGenResponse(swagger, apiPath, operation, response, config, consume,
   if (data.requestData && data.requestData.length > 0) {
     result = '';
     for (var i = 0; i < data.requestData.length; i++) {
+      data = setPathParamsFromArray(data, config, i);
       data.request = JSON.stringify(data.requestData[i].body);
 
       for (var key in data.requestData[i]) {
@@ -333,7 +360,9 @@ function testGenOperation(swagger, apiPath, operation, config, info) {
   if (config.statusCodes) {
     responses = {};
     config.statusCodes.forEach(function(code) {
-      responses[code] = swagger.paths[apiPath][operation].responses[code];
+      if (swagger.paths[apiPath][operation].responses[code]) {
+        responses[code] = swagger.paths[apiPath][operation].responses[code];
+      }
     });
   }
 

--- a/test/request-data/.eslintrc
+++ b/test/request-data/.eslintrc
@@ -1,0 +1,11 @@
+extends: ../../.eslintrc
+env:
+  mocha: true
+rules:
+  indent: false
+  no-unused-expressions: false
+  valid-jsdoc: 0;
+  quotes: [0]
+  key-spacing: false
+  quote-props: false
+  comma-spacing: false

--- a/test/request-data/compare/request/expect/non-standard-c-type-products-test.js
+++ b/test/request-data/compare/request/expect/non-standard-c-type-products-test.js
@@ -24,6 +24,25 @@ describe('/products', function() {
         done();
       });
     });
+  it('should respond with 200 OK and some description', function(done) {
+      request({
+        url: 'https://api.uber.com/products',
+        json: true,
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/vnd:something+json'
+        },
+        body: {"id":1,"name":"product"}
+      },
+      function(error, res, body) {
+        if (error) return done(error);
+
+        expect(res.statusCode).to.equal(200);
+
+        expect(body).to.equal(null); // non-json response or no schema
+        done();
+      });
+    });
 
   });
 

--- a/test/request-data/compare/request/expect/non-standard-c-type-products-{id}-test.js
+++ b/test/request-data/compare/request/expect/non-standard-c-type-products-{id}-test.js
@@ -91,6 +91,42 @@ describe('/products/{id}', function() {
         done();
       });
     });
+  it('should respond with 200 Return product and some other description', function(done) {
+      /*eslint-disable*/
+      var schema = {
+        "type": "object",
+        "required": [
+          "id",
+          "name"
+        ],
+        "properties": {
+          "id": {
+            "type": "number"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      };
+
+      /*eslint-enable*/
+      request({
+        url: 'https://api.uber.com/products/3',
+        json: true,
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      },
+      function(error, res, body) {
+        if (error) return done(error);
+
+        expect(res.statusCode).to.equal(200);
+
+        expect(validator.validate(body, schema)).to.be.true;
+        done();
+      });
+    });
 
   });
 
@@ -98,6 +134,25 @@ describe('/products/{id}', function() {
     it('should respond with 200 OK and some description', function(done) {
       request({
         url: 'https://api.uber.com/products/2',
+        json: true,
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/vnd:something+Json'
+        },
+        body: {}
+      },
+      function(error, res, body) {
+        if (error) return done(error);
+
+        expect(res.statusCode).to.equal(200);
+
+        expect(body).to.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+  it('should respond with 200 OK and some other description', function(done) {
+      request({
+        url: 'https://api.uber.com/products/3',
         json: true,
         method: 'PUT',
         headers: {

--- a/test/request-data/compare/request/expect/qs1-user-test.js
+++ b/test/request-data/compare/request/expect/qs1-user-test.js
@@ -27,6 +27,28 @@ describe('/user', function() {
         done();
       });
     });
+  it('should respond with 200 OK and some other description', function(done) {
+      request({
+        url: 'https://api.uber.com/v1/user',
+        json: true,
+        qs: {
+          longitude: 20
+        },
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: {"my-id":3}
+      },
+      function(error, res, body) {
+        if (error) return done(error);
+
+        expect(res.statusCode).to.equal(200);
+
+        expect(body).to.equal(null); // non-json response or no schema
+        done();
+      });
+    });
 
     it('should respond with 400 NOT OK', function(done) {
       request({

--- a/test/request-data/compare/request/expect/qs2-user-test.js
+++ b/test/request-data/compare/request/expect/qs2-user-test.js
@@ -26,6 +26,27 @@ describe('/user', function() {
         done();
       });
     });
+  it('should respond with 200 OK and some other description', function(done) {
+      request({
+        url: 'https://api.uber.com/user',
+        json: true,
+        qs: {
+          longitude: 20
+        },
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      },
+      function(error, res, body) {
+        if (error) return done(error);
+
+        expect(res.statusCode).to.equal(200);
+
+        expect(body).to.equal(null); // non-json response or no schema
+        done();
+      });
+    });
 
     it('should respond with 400 NOT OK', function(done) {
       request({

--- a/test/request-data/compare/request/expect/qs3-user-test.js
+++ b/test/request-data/compare/request/expect/qs3-user-test.js
@@ -26,6 +26,27 @@ describe('/user', function() {
         done();
       });
     });
+  it('should respond with 200 OK and some other description', function(done) {
+      request({
+        url: 'https://api.uber.com/user',
+        json: true,
+        qs: {
+          name: 'Garfunkel'
+        },
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      },
+      function(error, res, body) {
+        if (error) return done(error);
+
+        expect(res.statusCode).to.equal(200);
+
+        expect(body).to.equal(null); // non-json response or no schema
+        done();
+      });
+    });
 
     it('should respond with 400 NOT OK', function(done) {
       request({

--- a/test/request-data/compare/request/expect/qs4-user-test.js
+++ b/test/request-data/compare/request/expect/qs4-user-test.js
@@ -47,6 +47,27 @@ describe('/user', function() {
         done();
       });
     });
+  it('should respond with 200 OK and yet another description', function(done) {
+      request({
+        url: 'https://api.uber.com/user',
+        json: true,
+        qs: {
+          name: 'Dave'
+        },
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      },
+      function(error, res, body) {
+        if (error) return done(error);
+
+        expect(res.statusCode).to.equal(200);
+
+        expect(body).to.equal(null); // non-json response or no schema
+        done();
+      });
+    });
 
     it('should respond with 400 NOT OK', function(done) {
       request({

--- a/test/request-data/compare/request/expect/qs4-user-test.js
+++ b/test/request-data/compare/request/expect/qs4-user-test.js
@@ -1,0 +1,97 @@
+'use strict';
+var chai = require('chai');
+var request = require('request');
+var expect = chai.expect;
+
+describe('/user', function() {
+  describe('get', function() {
+    it('should respond with 200 OK and some description', function(done) {
+      request({
+        url: 'https://api.uber.com/user',
+        json: true,
+        qs: {
+          name: 'Miles'
+        },
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      },
+      function(error, res, body) {
+        if (error) return done(error);
+
+        expect(res.statusCode).to.equal(200);
+
+        expect(body).to.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+  it('should respond with 200 OK and some other description', function(done) {
+      request({
+        url: 'https://api.uber.com/user',
+        json: true,
+        qs: {
+          name: 'John',nickname: 'Trane'
+        },
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      },
+      function(error, res, body) {
+        if (error) return done(error);
+
+        expect(res.statusCode).to.equal(200);
+
+        expect(body).to.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 400 NOT OK', function(done) {
+      request({
+        url: 'https://api.uber.com/user',
+        json: true,
+        qs: {
+          name: 'DATA GOES HERE',nickname: 'DATA GOES HERE'
+        },
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      },
+      function(error, res, body) {
+        if (error) return done(error);
+
+        expect(res.statusCode).to.equal(400);
+
+        expect(body).to.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+    it('should respond with 500 SERVER ERROR', function(done) {
+      request({
+        url: 'https://api.uber.com/user',
+        json: true,
+        qs: {
+          name: 'DATA GOES HERE',nickname: 'DATA GOES HERE'
+        },
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      },
+      function(error, res, body) {
+        if (error) return done(error);
+
+        expect(res.statusCode).to.equal(500);
+
+        expect(body).to.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/request-data/compare/request/expect/user-test.js
+++ b/test/request-data/compare/request/expect/user-test.js
@@ -27,6 +27,28 @@ describe('/user', function() {
         done();
       });
     });
+  it('should respond with 200 OK and some other description', function(done) {
+      request({
+        url: 'https://api.uber.com/v1/user',
+        json: true,
+        qs: {
+          longitude: 'DATA GOES HERE'
+        },
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: {"my-id":3}
+      },
+      function(error, res, body) {
+        if (error) return done(error);
+
+        expect(res.statusCode).to.equal(200);
+
+        expect(body).to.equal(null); // non-json response or no schema
+        done();
+      });
+    });
 
     it('should respond with 400 NOT OK', function(done) {
       request({

--- a/test/request-data/compare/request/expect/with-headers-user-test.js
+++ b/test/request-data/compare/request/expect/with-headers-user-test.js
@@ -25,6 +25,26 @@ describe('/user', function() {
         done();
       });
     });
+  it('should respond with 200 OK and some other description', function(done) {
+      request({
+        url: 'https://api.uber.com/user',
+        json: true,
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Longitude': 'DATA GOES HERE',
+          'X-Token': 'qwerty'
+        }
+      },
+      function(error, res, body) {
+        if (error) return done(error);
+
+        expect(res.statusCode).to.equal(200);
+
+        expect(body).to.equal(null); // non-json response or no schema
+        done();
+      });
+    });
 
     it('should respond with 400 NOT OK', function(done) {
       request({

--- a/test/request-data/swagger-get2-optional.json
+++ b/test/request-data/swagger-get2-optional.json
@@ -1,0 +1,44 @@
+{
+    "swagger": "2.0",
+    "info": {
+        "version": "0.0.0",
+        "title": "Simple API"
+    },
+    "host": "api.uber.com",
+    "schemes": [
+        "https"
+    ],
+    "paths": {
+        "/user": {
+            "get": {
+                "parameters": [
+                    {
+                        "name": "name",
+                        "in": "query",
+                        "description": "name.",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "name": "nickname",
+                        "in": "query",
+                        "description": "nickname.",
+                        "required": false,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    },
+                    "400": {
+                        "description": "NOT OK"
+                    },
+                    "500": {
+                        "description": "SERVER ERROR"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/test/request-data/test.js
+++ b/test/request-data/test.js
@@ -309,7 +309,8 @@ describe('request data population', function() {
               get: {
                 200: [
                   {name: 'Miles', description: 'some description'},
-                  {name: 'John', nickname: 'Trane', description: 'some other description'}
+                  {name: 'John', nickname: 'Trane', description: 'some other description'},
+                  {name: 'Dave', description: 'yet another description'}
                 ]
               }
             }

--- a/test/request-data/test.js
+++ b/test/request-data/test.js
@@ -36,7 +36,7 @@ var join = require('path').join;
 var rules;
 var read = require('fs').readFileSync;
 
-rules = yaml.safeLoad(read(join(__dirname, '/../../.eslintrc'), 'utf8'));
+rules = yaml.safeLoad(read(join(__dirname, './.eslintrc'), 'utf8'));
 rules.env = {mocha: true};
 
 describe('request data population', function() {
@@ -51,7 +51,10 @@ describe('request data population', function() {
           requestData: {
             '/user': {
               post: {
-                200: [{body: {"my-id": 2}, description: 'some description'}]
+                200: [
+                  {body: {"my-id": 2}, description: 'some description'},
+                  {body: {"my-id": 3}, description: 'some other description'}
+                ]
               }
             }
           }
@@ -97,6 +100,10 @@ describe('request data population', function() {
                   {
                     body: {},
                     description: 'some description'
+                  },
+                  {
+                    body: {id: 1, name: 'product'},
+                    description: 'some description'
                   }
                 ]
               }
@@ -107,6 +114,10 @@ describe('request data population', function() {
                   {
                     id: 2,
                     description: 'some description'
+                  },
+                  {
+                    id: 3,
+                    description: 'some other description'
                   }
                 ]
               },
@@ -116,6 +127,11 @@ describe('request data population', function() {
                     id: 2,
                     body: {},
                     description: 'some description'
+                  },
+                  {
+                    id: 3,
+                    body: {},
+                    description: 'some other description'
                   }
                 ]
               }
@@ -158,7 +174,10 @@ describe('request data population', function() {
           requestData: {
             '/user': {
               post: {
-                200: [{body: {"my-id": 2}, longitude: 10, description: 'some description'}]
+                200: [
+                  {body: {"my-id": 2}, longitude: 10, description: 'some description'},
+                  {body: {"my-id": 3}, longitude: 20, description: 'some other description'}
+              ]
               }
             }
           }
@@ -200,7 +219,10 @@ describe('request data population', function() {
         requestData: {
           '/user': {
             get: {
-              200: [{longitude: 10, description: 'some description'}]
+              200: [
+                {longitude: 10, description: 'some description'},
+                {longitude: 20, description: 'some other description'}
+              ]
             }
           }
         }
@@ -240,7 +262,10 @@ describe('request data population', function() {
           requestData: {
             '/user': {
               get: {
-                200: [{name: 'Simon', description: 'some description'}]
+                200: [
+                  {name: 'Simon', description: 'some description'},
+                  {name: 'Garfunkel', description: 'some other description'}
+                ]
               }
             }
           }
@@ -282,7 +307,10 @@ describe('request data population', function() {
         requestData: {
           '/user': {
             get: {
-              200: [{'X-Token': 'sadfg', description: 'some description'}]
+              200: [
+                {'X-Token': 'sadfg', description: 'some description'},
+                {'X-Token': 'qwerty', description: 'some other description'}
+            ]
             }
           }
         }

--- a/test/request-data/test.js
+++ b/test/request-data/test.js
@@ -29,6 +29,7 @@ var testGen = require('../../index.js').testGen;
 var swaggerPost = require('./swagger-post.json');
 var swaggerGet = require('./swagger-get.json');
 var swaggerGet2 = require('./swagger-get2.json');
+var swaggerGet2Optional = require('./swagger-get2-optional.json');
 var swaggerGetWithHeaders = require('./swagger-get-with-headers.json');
 var swaggerNonStandardContentType = require('./swagger-with-non-standard-content-type.json');
 var yaml = require('js-yaml');
@@ -290,6 +291,50 @@ describe('request data population', function() {
             if (paths1 !== undefined) {
               generatedCode = read(paths1[ndx], 'utf8').replace(/\r\n/g, '\n');
               assert.equal(output4[ndx].test.replace(/\r\n/g, '\n'), generatedCode);
+            }
+          }
+        });
+      });
+    });
+
+    describe('with optional parameter', function() {
+      describe('expect', function() {
+        var output5 = testGen(swaggerGet2Optional, {
+          assertionFormat: 'expect',
+          pathName: [],
+          testModule: 'request',
+          maxLen: -1,
+          requestData: {
+            '/user': {
+              get: {
+                200: [
+                  {name: 'Miles', description: 'some description'},
+                  {name: 'John', nickname: 'Trane', description: 'some other description'}
+                ]
+              }
+            }
+          }
+        });
+
+        var paths1 = [];
+        var ndx;
+
+        for (ndx in output5) {
+          if (output5) {
+            paths1.push(join(__dirname, '/compare/request/expect/qs4-' + output5[ndx].name));
+          }
+        }
+
+        it('should populate query parameters in test description', function() {
+          assert.isArray(output5);
+          assert.lengthOf(output5, 1);
+
+          var generatedCode;
+
+          for (ndx in paths1) {
+            if (paths1 !== undefined) {
+              generatedCode = read(paths1[ndx], 'utf8').replace(/\r\n/g, '\n');
+              assert.equal(output5[ndx].test.replace(/\r\n/g, '\n'), generatedCode);
             }
           }
         });

--- a/test/statuscode-multiple/compare/request/{id}-test.js
+++ b/test/statuscode-multiple/compare/request/{id}-test.js
@@ -1,0 +1,77 @@
+'use strict';
+var chai = require('chai');
+var request = require('request');
+
+chai.should();
+
+describe('/{id}', function() {
+  describe('get', function() {
+    it('should respond with 200 OK', function(done) {
+      request({
+        url: 'http://basic.herokuapp.com/{id PARAM GOES HERE}',
+        json: true,
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      },
+      function(error, res, body) {
+        if (error) return done(error);
+
+        res.statusCode.should.equal(200);
+
+        body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+  });
+
+  describe('put', function() {
+    it('should respond with 202 OK, but not 200', function(done) {
+      request({
+        url: 'http://basic.herokuapp.com/{id PARAM GOES HERE}',
+        json: true,
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: {
+          body: 'DATA GOES HERE'
+        }
+      },
+      function(error, res, body) {
+        if (error) return done(error);
+
+        res.statusCode.should.equal(202);
+
+        body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+  });
+
+  describe('delete', function() {
+    it('should respond with 204 OK, but not 200', function(done) {
+      request({
+        url: 'http://basic.herokuapp.com/{id PARAM GOES HERE}',
+        json: true,
+        method: 'DELETE',
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      },
+      function(error, res, body) {
+        if (error) return done(error);
+
+        res.statusCode.should.equal(204);
+
+        body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/statuscode-multiple/swagger-rud.json
+++ b/test/statuscode-multiple/swagger-rud.json
@@ -1,0 +1,64 @@
+{
+    "swagger": "2.0",
+    "info": {
+        "version": "0.0.0",
+        "title": "Simple API"
+    },
+    "host": "basic.herokuapp.com",
+    "paths": {
+        "/{id}": {
+            "parameters": [
+                {
+                    "name": "id",
+                    "in": "path",
+                    "required": true,
+                    "type": "string"
+                }
+            ],
+            "get": {
+                "operationId": "GET",
+                "summary": "Get",
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    },
+                    "500": {
+                        "description": "Error"
+                    }
+                }
+            },
+            "put": {
+                "operationId": "PUT",
+                "summary": "Update",
+                "parameters": [
+                    {
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "202": {
+                        "description": "OK, but not 200"
+                    },
+                    "500": {
+                        "description": "Error"
+                    }
+                }
+            },
+            "delete": {
+                "operationId": "DELETE",
+                "summary": "Delete",
+                "responses": {
+                    "204": {
+                        "description": "OK, but not 200"
+                    },
+                    "500": {
+                        "description": "Error"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/test/statuscode-multiple/test.js
+++ b/test/statuscode-multiple/test.js
@@ -1,0 +1,74 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Apigee Corporation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+
+/**
+ * This files tests is the user can set the template location
+ */
+'use strict';
+
+var assert = require('chai').assert;
+var testGen = require('../../index.js').testGen;
+var swagger = require('./swagger-rud.json');
+var yaml = require('js-yaml');
+var join = require('path').join;
+var rules;
+
+var fs = require('fs');
+
+rules = yaml.safeLoad(fs.readFileSync(join(__dirname,
+  '/../../.eslintrc'), 'utf8'));
+rules.env = {mocha: true};
+
+describe('Multiple UserDefined status codes', function() {
+  var output = testGen(swagger, {
+    assertionFormat: 'should',
+    pathNames: [],
+    testModule: 'request',
+    statusCodes: [200, 202, 204]
+  });
+
+  it('should only generate code for the supplied codes', function() {
+    var paths1 = [];
+    var ndx;
+
+    for (ndx in output) {
+      if (output) {
+        paths1.push(join(__dirname, '/compare/request/' + output[ndx].name));
+      }
+    }
+
+    assert.isArray(output);
+    assert.lengthOf(output, 1);
+
+    var generatedCode;
+
+    for (ndx in paths1) {
+      if (paths1 !== undefined) {
+        generatedCode = fs.readFileSync(paths1[ndx], 'utf8');
+        assert.equal(output[ndx].test, generatedCode);
+      }
+    }
+  });
+});


### PR DESCRIPTION
Made possible to specify multiple request data object for a response as described here: https://github.com/apigee-127/swagger-test-templates/issues/161
and requested in 
https://github.com/apigee-127/swagger-test-templates/issues/128

Made config status codes match to status codes in response, so that endpoints with different success codes can be tested

Some ESLint rules don't pass for generated multiple request data scripts, so had to disable them.