### PR TITLE
Ensure "descriptions" are correctly formatted as JavaScript strings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,5 @@ node_modules
 .idea
 test/instagram
 test/templatesPath/userTemplateDirectory/**/*.handlebars
+package-lock.json
+.vscode/

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -3,6 +3,8 @@
 var _ = require('lodash');
 var strObj = require('string');
 var url = require('url');
+var jsStringEscape = require('js-string-escape');
+
 var len;
 
 module.exports = {
@@ -183,11 +185,12 @@ function length(description) {
       'requires path to be a string');
   }
 
-  if (len === -1) { // toggle off truncation, this is a noop
-    return description;
+  var desc = description;
+  if (len !== -1) {
+    description = strObj(description).truncate(len - 50).s;
   }
 
-  return strObj(description).truncate(len - 50).s;
+  return jsStringEscape(description);
 }
 
 function printJSON(data) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swagger-test-templates",
-  "version": "1.4.2",
+  "version": "1.5.1",
   "description": "Generate test code from a Swagger spec",
   "main": "index.js",
   "scripts": {
@@ -50,6 +50,7 @@
   },
   "dependencies": {
     "handlebars": "^4.0.5",
+    "js-string-escape": "^1.0.1",
     "json-schema-deref-sync": "^0.3.1",
     "lodash": "^3.10.0",
     "sanitize-filename": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swagger-test-templates",
-  "version": "1.5.1",
+  "version": "1.4.2",
   "description": "Generate test code from a Swagger spec",
   "main": "index.js",
   "scripts": {

--- a/test/length/compare/request/.eslintrc
+++ b/test/length/compare/request/.eslintrc
@@ -1,0 +1,5 @@
+---
+  extends: ../../../.eslintrc
+  rules:
+    max-len: 'off'
+

--- a/test/length/compare/request/default-base-path-test.js
+++ b/test/length/compare/request/default-base-path-test.js
@@ -6,7 +6,7 @@ chai.should();
 
 describe('/', function() {
   describe('get', function() {
-    it('should respond with 200 OK, and this description is extra long for a simple length toggle test!', function(done) {
+    it('should respond with 200 \'OK\'\n\\/\"This description...', function(done) {
       request({
         url: 'http://basic.herokuapp.com/',
         json: true,

--- a/test/length/compare/request/t20-base-path-test.js
+++ b/test/length/compare/request/t20-base-path-test.js
@@ -1,0 +1,30 @@
+'use strict';
+var chai = require('chai');
+var request = require('request');
+
+chai.should();
+
+describe('/', function() {
+  describe('get', function() {
+    it('should respond with 200 \'OK\'\n\\/\"This description is extra long for a simple length toggle test!\" It needs to...', function(done) {
+      request({
+        url: 'http://basic.herokuapp.com/',
+        json: true,
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      },
+      function(error, res, body) {
+        if (error) return done(error);
+
+        res.statusCode.should.equal(200);
+
+        body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/length/compare/request/toggle-base-path-test.js
+++ b/test/length/compare/request/toggle-base-path-test.js
@@ -1,0 +1,30 @@
+'use strict';
+var chai = require('chai');
+var request = require('request');
+
+chai.should();
+
+describe('/', function() {
+  describe('get', function() {
+    it('should respond with 200 \'OK\'\n\\/\"This description is extra long for a simple length toggle test!\" It needs to contain at least 80 characters', function(done) {
+      request({
+        url: 'http://basic.herokuapp.com/',
+        json: true,
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      },
+      function(error, res, body) {
+        if (error) return done(error);
+
+        res.statusCode.should.equal(200);
+
+        body.should.equal(null); // non-json response or no schema
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/length/swagger.json
+++ b/test/length/swagger.json
@@ -10,7 +10,7 @@
             "get": {
                 "responses": {
                     "200": {
-                        "description": "OK, and this description is extra long for a simple length toggle test!"
+                        "description": "'OK'\n\\/\"This description is extra long for a simple length toggle test!\" It needs to contain at least 80 characters"
                     },
                     "400": {
                       "description": "NOK"

--- a/test/length/test.js
+++ b/test/length/test.js
@@ -37,10 +37,10 @@ var rules;
 
 var fs = require('fs');
 
-rules = yaml.safeLoad(fs.readFileSync(join(__dirname,
-  '/../../.eslintrc'), 'utf8'));
+rules = yaml.safeLoad(fs.readFileSync(join(__dirname, '../../.eslintrc'), 'utf8'));
 rules.env = {mocha: true};
 
+// Turn off truncation
 describe('Toggle description truncation', function() {
   var output = testGen(swagger, {
     assertionFormat: 'should',
@@ -58,7 +58,77 @@ describe('Toggle description truncation', function() {
 
     for (ndx in output) {
       if (output) {
-        paths1.push(join(__dirname, '/compare/request/' + output[ndx].name));
+        paths1.push(join(__dirname, '/compare/request/toggle-' + output[ndx].name));
+      }
+    }
+
+    assert.isArray(output);
+    assert.lengthOf(output, 1);
+
+    var generatedCode;
+
+    for (ndx in paths1) {
+      if (paths1 !== undefined) {
+        generatedCode = fs.readFileSync(paths1[ndx], 'utf8');
+        assert.equal(output[ndx].test, generatedCode);
+      }
+    }
+  });
+});
+
+// Default truncation
+describe('Default truncation', function() {
+  var output = testGen(swagger, {
+    assertionFormat: 'should',
+    pathNames: [],
+    testModule: 'request',
+    statusCodes: [200]
+  });
+
+  it('should truncate the description at the default size', function() {
+
+    var paths1 = [];
+    var ndx;
+
+    for (ndx in output) {
+      if (output) {
+        paths1.push(join(__dirname, '/compare/request/default-' + output[ndx].name));
+      }
+    }
+
+    assert.isArray(output);
+    assert.lengthOf(output, 1);
+
+    var generatedCode;
+
+    for (ndx in paths1) {
+      if (paths1 !== undefined) {
+        generatedCode = fs.readFileSync(paths1[ndx], 'utf8');
+        assert.equal(output[ndx].test, generatedCode);
+      }
+    }
+  });
+});
+
+// Explicit truncation
+describe('Description truncate at 20', function() {
+  var output = testGen(swagger, {
+    assertionFormat: 'should',
+    pathNames: [],
+    testModule: 'request',
+    statusCodes: [200],
+    maxLen: 20
+
+  });
+
+  it('should truncate the description at 20 characters', function() {
+
+    var paths1 = [];
+    var ndx;
+
+    for (ndx in output) {
+      if (output) {
+        paths1.push(join(__dirname, '/compare/request/t20-' + output[ndx].name));
       }
     }
 


### PR DESCRIPTION
If a description in the Swagger source contains what JavaScript considers to be special characters, the resulting test source is ill-formed. This change:

- Augments the logic that optionally truncates descriptions when propagating to the output to also escape the string (after truncating, to ensure that escape sequences are not split by the truncation). This change is in the "length" helper function.
- Updates the "length" unit test to test different modes of description truncation, and not just "off". These tests also use special characters in the descriptions, thus testing this feature as well. These unit tests effectively test the "length" helper function.