### PR TITLE
package.json: Bump lodash to "^4.17.12"

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "handlebars": "^4.0.5",
     "js-string-escape": "^1.0.1",
     "json-schema-deref-sync": "^0.3.1",
-    "lodash": "^3.10.0",
+    "lodash": "^4.17.12",
     "sanitize-filename": "^1.3.0",
     "string": "^3.3.0"
   }


### PR DESCRIPTION
Doing an `npm audit` or `yarn audit` against this package shows lodash is out-of-date, and affected by some vulnerabilities.

This updates lodash to at least 4.17.12, to eliminate the warnings from running audits.