### PR TITLE
Fix/fix assert.true

### DIFF
--- a/index.js
+++ b/index.js
@@ -208,17 +208,18 @@ function getData(swagger, apiPath, operation, response, config, info) {
     // if we have requestData, fill the path params accordingly
     var mockParameters = {};
 
-    data.pathParameters.forEach(function(parameter) {
-      // find the mock data for this parameter name
-      mockParameters[parameter.name] = data.requestData.filter(function(mock) {
-        return mock.hasOwnProperty(parameter.name);
-      })[0][parameter.name];
-    });
-    // only write parameters if they are not already defined in config
-    // @todo we should rework this with code above to be more readable
-    if (!config.pathParams) {
+    if (config.pathParams) {
+      data.pathParams = config.pathParams
+    } else {
+      // no path params in config, get them from per-endpoint data
+      data.pathParameters.forEach(function(parameter) {
+        // find the mock data for this parameter name
+        mockParameters[parameter.name] = data.requestData.filter(function(mock) {
+          return mock.hasOwnProperty(parameter.name);
+        })[0][parameter.name];
+      });    
       data.pathParams = mockParameters;
-    }
+    }   
   }
   return data;
 }

--- a/index.js
+++ b/index.js
@@ -209,7 +209,7 @@ function getData(swagger, apiPath, operation, response, config, info) {
     var mockParameters = {};
 
     if (config.pathParams) {
-      data.pathParams = config.pathParams
+      data.pathParams = config.pathParams;
     } else {
       // no path params in config, get them from per-endpoint data
       data.pathParameters.forEach(function(parameter) {
@@ -217,9 +217,9 @@ function getData(swagger, apiPath, operation, response, config, info) {
         mockParameters[parameter.name] = data.requestData.filter(function(mock) {
           return mock.hasOwnProperty(parameter.name);
         })[0][parameter.name];
-      });    
+      });
       data.pathParams = mockParameters;
-    }   
+    }
   }
   return data;
 }

--- a/templates/request/delete/delete.handlebars
+++ b/templates/request/delete/delete.handlebars
@@ -58,7 +58,7 @@
         validator.validate(body, schema).should.be.true;
         {{/is}}
         {{#is assertion 'assert'}}
-        assert.true(validator.validate(body, schema));
+        assert(validator.validate(body, schema), 'Schema validation failed');
         {{/is}}
         {{else}}
         {{#is assertion 'expect'}}

--- a/templates/request/get/get.handlebars
+++ b/templates/request/get/get.handlebars
@@ -58,7 +58,7 @@
         validator.validate(body, schema).should.be.true;
         {{/is}}
         {{#is assertion 'assert'}}
-        assert.true(validator.validate(body, schema));
+        assert(validator.validate(body, schema), 'Schema validation failed');
         {{/is}}
         {{else}}
         {{#isPdfMediaType returnType}}

--- a/templates/request/patch/patch.handlebars
+++ b/templates/request/patch/patch.handlebars
@@ -87,7 +87,7 @@
         validator.validate(body, schema).should.be.true;
         {{/is}}
         {{#is assertion 'assert'}}
-        assert.true(validator.validate(body, schema));
+        assert(validator.validate(body, schema), 'Schema validation failed');
         {{/is}}
         {{else}}
         {{#isPdfMediaType returnType}}

--- a/templates/request/post/post.handlebars
+++ b/templates/request/post/post.handlebars
@@ -85,7 +85,7 @@
         validator.validate(body, schema).should.be.true;
         {{/is}}
         {{#is assertion 'assert'}}
-        assert.true(validator.validate(body, schema));
+        assert(validator.validate(body, schema), 'Schema validation failed');
         {{/is}}
         {{else}}
         {{#isPdfMediaType returnType}}

--- a/templates/request/put/put.handlebars
+++ b/templates/request/put/put.handlebars
@@ -85,7 +85,7 @@
         validator.validate(body, schema).should.be.true;
         {{/is}}
         {{#is assertion 'assert'}}
-        assert.true(validator.validate(body, schema));
+        assert(validator.validate(body, schema), 'Schema validation failed');
         {{/is}}
         {{else}}
         {{#isPdfMediaType returnType}}

--- a/templates/supertest/delete/delete.handlebars
+++ b/templates/supertest/delete/delete.handlebars
@@ -43,7 +43,7 @@
         validator.validate(res.body, schema).should.be.true;
         {{/is}}
         {{#is assertion 'assert'}}
-        assert.true(validator.validate(res.body, schema));
+        assert(validator.validate(res.body, schema));
         {{/is}}
         {{else}}
         {{#is assertion 'expect'}}

--- a/templates/supertest/delete/delete.handlebars
+++ b/templates/supertest/delete/delete.handlebars
@@ -43,7 +43,7 @@
         validator.validate(res.body, schema).should.be.true;
         {{/is}}
         {{#is assertion 'assert'}}
-        assert(validator.validate(res.body, schema), 'Schema validation failed');
+        assert(validator.validate(res.body, schema), 'Schema validation failed: ' + JSON.stringify(validator.getLastErrors()));
         {{/is}}
         {{else}}
         {{#is assertion 'expect'}}

--- a/templates/supertest/delete/delete.handlebars
+++ b/templates/supertest/delete/delete.handlebars
@@ -43,7 +43,7 @@
         validator.validate(res.body, schema).should.be.true;
         {{/is}}
         {{#is assertion 'assert'}}
-        assert(validator.validate(res.body, schema));
+        assert(validator.validate(res.body, schema), 'Schema validation failed');
         {{/is}}
         {{else}}
         {{#is assertion 'expect'}}

--- a/templates/supertest/delete/delete.handlebars
+++ b/templates/supertest/delete/delete.handlebars
@@ -53,7 +53,7 @@
         res.body.should.equal(null); // non-json response or no schema
         {{/is}}
         {{#is assertion 'assert'}}
-        assert.isNull(res.body); // non-json response or no schema
+        assert((Object.keys(res.body).length === 0) || (res.body === null)); // non-json response (sets body to empty obj) or no schema
         {{/is}}
         {{/validateResponse}}
         done();

--- a/templates/supertest/get/get.handlebars
+++ b/templates/supertest/get/get.handlebars
@@ -43,7 +43,7 @@
         validator.validate(res.body, schema).should.be.true;
         {{/is}}
         {{#is assertion 'assert'}}
-        assert(validator.validate(res.body, schema));
+        assert(validator.validate(res.body, schema), 'Schema validation failed');
         {{/is}}
         {{else}}
         {{#isPdfMediaType returnType}}

--- a/templates/supertest/get/get.handlebars
+++ b/templates/supertest/get/get.handlebars
@@ -43,7 +43,7 @@
         validator.validate(res.body, schema).should.be.true;
         {{/is}}
         {{#is assertion 'assert'}}
-        assert.true(validator.validate(res.body, schema));
+        assert(validator.validate(res.body, schema));
         {{/is}}
         {{else}}
         {{#isPdfMediaType returnType}}

--- a/templates/supertest/get/get.handlebars
+++ b/templates/supertest/get/get.handlebars
@@ -64,7 +64,7 @@
         res.body.should.equal(null); // non-json response or no schema
         {{/is}}
         {{#is assertion 'assert'}}
-        assert.isNull(res.body); // non-json response or no schema
+        assert((Object.keys(res.body).length === 0) || (res.body === null)); // non-json response (sets body to empty obj) or no schema
         {{/is}}
         {{/isPdfMediaType}}
         {{/validateResponse}}

--- a/templates/supertest/get/get.handlebars
+++ b/templates/supertest/get/get.handlebars
@@ -43,7 +43,7 @@
         validator.validate(res.body, schema).should.be.true;
         {{/is}}
         {{#is assertion 'assert'}}
-        assert(validator.validate(res.body, schema), 'Schema validation failed');
+        assert(validator.validate(res.body, schema), 'Schema validation failed: ' + JSON.stringify(validator.getLastErrors()));
         {{/is}}
         {{else}}
         {{#isPdfMediaType returnType}}

--- a/templates/supertest/options/options.handlebars
+++ b/templates/supertest/options/options.handlebars
@@ -43,7 +43,7 @@
         validator.validate(res.body, schema).should.be.true;
         {{/is}}
         {{#is assertion 'assert'}}
-        assert.true(validator.validate(res.body, schema));
+        assert(validator.validate(res.body, schema));
         {{/is}}
         {{else}}
         {{#is assertion 'expect'}}

--- a/templates/supertest/options/options.handlebars
+++ b/templates/supertest/options/options.handlebars
@@ -43,7 +43,7 @@
         validator.validate(res.body, schema).should.be.true;
         {{/is}}
         {{#is assertion 'assert'}}
-        assert(validator.validate(res.body, schema), 'Schema validation failed');
+        assert(validator.validate(res.body, schema), 'Schema validation failed: ' + JSON.stringify(validator.getLastErrors()));
         {{/is}}
         {{else}}
         {{#is assertion 'expect'}}

--- a/templates/supertest/options/options.handlebars
+++ b/templates/supertest/options/options.handlebars
@@ -43,7 +43,7 @@
         validator.validate(res.body, schema).should.be.true;
         {{/is}}
         {{#is assertion 'assert'}}
-        assert(validator.validate(res.body, schema));
+        assert(validator.validate(res.body, schema), 'Schema validation failed');
         {{/is}}
         {{else}}
         {{#is assertion 'expect'}}

--- a/templates/supertest/options/options.handlebars
+++ b/templates/supertest/options/options.handlebars
@@ -53,7 +53,7 @@
         res.body.should.equal(null); // non-json response or no schema
         {{/is}}
         {{#is assertion 'assert'}}
-        assert.isNull(res.body); // non-json response or no schema
+        assert((Object.keys(res.body).length === 0) || (res.body === null)); // non-json response (sets body to empty obj) or no schema
         {{/is}}
         {{/validateResponse}}
         done();

--- a/templates/supertest/patch/patch.handlebars
+++ b/templates/supertest/patch/patch.handlebars
@@ -89,7 +89,7 @@
         res.body.should.equal(null); // non-json response or no schema
         {{/is}}
         {{#is assertion 'assert'}}
-        assert.isNull(res.body); // non-json response or no schema
+        assert((Object.keys(res.body).length === 0) || (res.body === null)); // non-json response (sets body to empty obj) or no schema
         {{/is}}
         {{/isPdfMediaType}}
         {{/validateResponse}}

--- a/templates/supertest/patch/patch.handlebars
+++ b/templates/supertest/patch/patch.handlebars
@@ -68,7 +68,7 @@
         validator.validate(res.body, schema).should.be.true;
         {{/is}}
         {{#is assertion 'assert'}}
-        assert(validator.validate(res.body, schema));
+        assert(validator.validate(res.body, schema), 'Schema validation failed');
         {{/is}}
         {{else}}
         {{#isPdfMediaType returnType}}

--- a/templates/supertest/patch/patch.handlebars
+++ b/templates/supertest/patch/patch.handlebars
@@ -68,7 +68,7 @@
         validator.validate(res.body, schema).should.be.true;
         {{/is}}
         {{#is assertion 'assert'}}
-        assert(validator.validate(res.body, schema), 'Schema validation failed');
+        assert(validator.validate(res.body, schema), 'Schema validation failed: ' + JSON.stringify(validator.getLastErrors()));
         {{/is}}
         {{else}}
         {{#isPdfMediaType returnType}}

--- a/templates/supertest/patch/patch.handlebars
+++ b/templates/supertest/patch/patch.handlebars
@@ -68,7 +68,7 @@
         validator.validate(res.body, schema).should.be.true;
         {{/is}}
         {{#is assertion 'assert'}}
-        assert.true(validator.validate(res.body, schema));
+        assert(validator.validate(res.body, schema));
         {{/is}}
         {{else}}
         {{#isPdfMediaType returnType}}

--- a/templates/supertest/post/post.handlebars
+++ b/templates/supertest/post/post.handlebars
@@ -67,7 +67,7 @@
         validator.validate(res.body, schema).should.be.true;
         {{/is}}
         {{#is assertion 'assert'}}
-        assert(validator.validate(res.body, schema));
+        assert(validator.validate(res.body, schema), 'Schema validation failed');
         {{/is}}
         {{else}}
         {{#isPdfMediaType returnType}}

--- a/templates/supertest/post/post.handlebars
+++ b/templates/supertest/post/post.handlebars
@@ -67,7 +67,7 @@
         validator.validate(res.body, schema).should.be.true;
         {{/is}}
         {{#is assertion 'assert'}}
-        assert(validator.validate(res.body, schema), 'Schema validation failed');
+        assert(validator.validate(res.body, schema), 'Schema validation failed: ' + JSON.stringify(validator.getLastErrors()));
         {{/is}}
         {{else}}
         {{#isPdfMediaType returnType}}

--- a/templates/supertest/post/post.handlebars
+++ b/templates/supertest/post/post.handlebars
@@ -88,7 +88,7 @@
         res.body.should.equal(null); // non-json response or no schema
         {{/is}}
         {{#is assertion 'assert'}}
-        assert.isNull(res.body); // non-json response or no schema
+        assert((Object.keys(res.body).length === 0) || (res.body === null)); // non-json response (sets body to empty obj) or no schema
         {{/is}}
         {{/isPdfMediaType}}
         {{/validateResponse}}

--- a/templates/supertest/post/post.handlebars
+++ b/templates/supertest/post/post.handlebars
@@ -67,7 +67,7 @@
         validator.validate(res.body, schema).should.be.true;
         {{/is}}
         {{#is assertion 'assert'}}
-        assert.true(validator.validate(res.body, schema));
+        assert(validator.validate(res.body, schema));
         {{/is}}
         {{else}}
         {{#isPdfMediaType returnType}}

--- a/templates/supertest/put/put.handlebars
+++ b/templates/supertest/put/put.handlebars
@@ -67,7 +67,7 @@
         validator.validate(res.body, schema).should.be.true;
         {{/is}}
         {{#is assertion 'assert'}}
-        assert(validator.validate(res.body, schema));
+        assert(validator.validate(res.body, schema), 'Schema validation failed');
         {{/is}}
         {{else}}
         {{#isPdfMediaType returnType}}

--- a/templates/supertest/put/put.handlebars
+++ b/templates/supertest/put/put.handlebars
@@ -67,7 +67,7 @@
         validator.validate(res.body, schema).should.be.true;
         {{/is}}
         {{#is assertion 'assert'}}
-        assert(validator.validate(res.body, schema), 'Schema validation failed');
+        assert(validator.validate(res.body, schema), 'Schema validation failed: ' + JSON.stringify(validator.getLastErrors()));
         {{/is}}
         {{else}}
         {{#isPdfMediaType returnType}}

--- a/templates/supertest/put/put.handlebars
+++ b/templates/supertest/put/put.handlebars
@@ -88,7 +88,7 @@
         res.body.should.equal(null); // non-json response or no schema
         {{/is}}
         {{#is assertion 'assert'}}
-        assert.isNull(res.body); // non-json response or no schema
+        assert((Object.keys(res.body).length === 0) || (res.body === null)); // non-json response (sets body to empty obj) or no schema
         {{/is}}
         {{/isPdfMediaType}}
         {{/validateResponse}}

--- a/templates/supertest/put/put.handlebars
+++ b/templates/supertest/put/put.handlebars
@@ -67,7 +67,7 @@
         validator.validate(res.body, schema).should.be.true;
         {{/is}}
         {{#is assertion 'assert'}}
-        assert.true(validator.validate(res.body, schema));
+        assert(validator.validate(res.body, schema));
         {{/is}}
         {{else}}
         {{#isPdfMediaType returnType}}

--- a/test/loadTest/compare/request/assert/base-path-test.js
+++ b/test/loadTest/compare/request/assert/base-path-test.js
@@ -88,7 +88,7 @@ describe('/', function() {
 
         assert.equal(res.statusCode, 200);
 
-        assert.true(validator.validate(body, schema));
+        assert(validator.validate(body, schema), 'Schema validation failed');
         done();
       });
     });
@@ -120,7 +120,7 @@ describe('/', function() {
 
         assert.equal(res.statusCode, 400);
 
-        assert.true(validator.validate(body, schema));
+        assert(validator.validate(body, schema), 'Schema validation failed');
         done();
       });
     });
@@ -164,7 +164,7 @@ describe('/', function() {
 
         assert.equal(res.statusCode, 500);
 
-        assert.true(validator.validate(body, schema));
+        assert(validator.validate(body, schema), 'Schema validation failed');
         done();
       });
     });
@@ -210,7 +210,7 @@ describe('/', function() {
 
         assert.equal(res.statusCode, 200);
 
-        assert.true(validator.validate(body, schema));
+        assert(validator.validate(body, schema), 'Schema validation failed');
         done();
       });
     });
@@ -242,7 +242,7 @@ describe('/', function() {
 
         assert.equal(res.statusCode, 400);
 
-        assert.true(validator.validate(body, schema));
+        assert(validator.validate(body, schema), 'Schema validation failed');
         done();
       });
     });
@@ -274,7 +274,7 @@ describe('/', function() {
 
         assert.equal(res.statusCode, 500);
 
-        assert.true(validator.validate(body, schema));
+        assert(validator.validate(body, schema), 'Schema validation failed');
         done();
       });
     });

--- a/test/loadTest/compare/supertest/assert/base-path-test.js
+++ b/test/loadTest/compare/supertest/assert/base-path-test.js
@@ -82,7 +82,7 @@ describe('/', function() {
       .end(function(err, res) {
         if (err) return done(err);
 
-        assert(validator.validate(res.body, schema));
+        assert(validator.validate(res.body, schema), 'Schema validation failed');
         done();
       });
     });
@@ -107,7 +107,7 @@ describe('/', function() {
       .end(function(err, res) {
         if (err) return done(err);
 
-        assert(validator.validate(res.body, schema));
+        assert(validator.validate(res.body, schema), 'Schema validation failed');
         done();
       });
     });
@@ -144,7 +144,7 @@ describe('/', function() {
       .end(function(err, res) {
         if (err) return done(err);
 
-        assert(validator.validate(res.body, schema));
+        assert(validator.validate(res.body, schema), 'Schema validation failed');
         done();
       });
     });
@@ -185,7 +185,7 @@ describe('/', function() {
       .end(function(err, res) {
         if (err) return done(err);
 
-        assert(validator.validate(res.body, schema));
+        assert(validator.validate(res.body, schema), 'Schema validation failed');
         done();
       });
     });
@@ -212,7 +212,7 @@ describe('/', function() {
       .end(function(err, res) {
         if (err) return done(err);
 
-        assert(validator.validate(res.body, schema));
+        assert(validator.validate(res.body, schema), 'Schema validation failed');
         done();
       });
     });
@@ -239,7 +239,7 @@ describe('/', function() {
       .end(function(err, res) {
         if (err) return done(err);
 
-        assert(validator.validate(res.body, schema));
+        assert(validator.validate(res.body, schema), 'Schema validation failed');
         done();
       });
     });

--- a/test/loadTest/compare/supertest/assert/base-path-test.js
+++ b/test/loadTest/compare/supertest/assert/base-path-test.js
@@ -82,7 +82,7 @@ describe('/', function() {
       .end(function(err, res) {
         if (err) return done(err);
 
-        assert.true(validator.validate(res.body, schema));
+        assert(validator.validate(res.body, schema));
         done();
       });
     });
@@ -107,7 +107,7 @@ describe('/', function() {
       .end(function(err, res) {
         if (err) return done(err);
 
-        assert.true(validator.validate(res.body, schema));
+        assert(validator.validate(res.body, schema));
         done();
       });
     });
@@ -144,7 +144,7 @@ describe('/', function() {
       .end(function(err, res) {
         if (err) return done(err);
 
-        assert.true(validator.validate(res.body, schema));
+        assert(validator.validate(res.body, schema));
         done();
       });
     });
@@ -185,7 +185,7 @@ describe('/', function() {
       .end(function(err, res) {
         if (err) return done(err);
 
-        assert.true(validator.validate(res.body, schema));
+        assert(validator.validate(res.body, schema));
         done();
       });
     });
@@ -212,7 +212,7 @@ describe('/', function() {
       .end(function(err, res) {
         if (err) return done(err);
 
-        assert.true(validator.validate(res.body, schema));
+        assert(validator.validate(res.body, schema));
         done();
       });
     });
@@ -239,7 +239,7 @@ describe('/', function() {
       .end(function(err, res) {
         if (err) return done(err);
 
-        assert.true(validator.validate(res.body, schema));
+        assert(validator.validate(res.body, schema));
         done();
       });
     });

--- a/test/loadTest/compare/supertest/assert/base-path-test.js
+++ b/test/loadTest/compare/supertest/assert/base-path-test.js
@@ -82,7 +82,7 @@ describe('/', function() {
       .end(function(err, res) {
         if (err) return done(err);
 
-        assert(validator.validate(res.body, schema), 'Schema validation failed');
+        assert(validator.validate(res.body, schema), 'Schema validation failed: ' + JSON.stringify(validator.getLastErrors()));
         done();
       });
     });
@@ -107,7 +107,7 @@ describe('/', function() {
       .end(function(err, res) {
         if (err) return done(err);
 
-        assert(validator.validate(res.body, schema), 'Schema validation failed');
+        assert(validator.validate(res.body, schema), 'Schema validation failed: ' + JSON.stringify(validator.getLastErrors()));
         done();
       });
     });
@@ -144,7 +144,7 @@ describe('/', function() {
       .end(function(err, res) {
         if (err) return done(err);
 
-        assert(validator.validate(res.body, schema), 'Schema validation failed');
+        assert(validator.validate(res.body, schema), 'Schema validation failed: ' + JSON.stringify(validator.getLastErrors()));
         done();
       });
     });
@@ -185,7 +185,7 @@ describe('/', function() {
       .end(function(err, res) {
         if (err) return done(err);
 
-        assert(validator.validate(res.body, schema), 'Schema validation failed');
+        assert(validator.validate(res.body, schema), 'Schema validation failed: ' + JSON.stringify(validator.getLastErrors()));
         done();
       });
     });
@@ -212,7 +212,7 @@ describe('/', function() {
       .end(function(err, res) {
         if (err) return done(err);
 
-        assert(validator.validate(res.body, schema), 'Schema validation failed');
+        assert(validator.validate(res.body, schema), 'Schema validation failed: ' + JSON.stringify(validator.getLastErrors()));
         done();
       });
     });
@@ -239,7 +239,7 @@ describe('/', function() {
       .end(function(err, res) {
         if (err) return done(err);
 
-        assert(validator.validate(res.body, schema), 'Schema validation failed');
+        assert(validator.validate(res.body, schema), 'Schema validation failed: ' + JSON.stringify(validator.getLastErrors()));
         done();
       });
     });

--- a/test/loadTest/compare/supertest/assert/user-test.js
+++ b/test/loadTest/compare/supertest/assert/user-test.js
@@ -17,7 +17,7 @@ describe('/user', function() {
       .end(function(err, res) {
         if (err) return done(err);
 
-        assert.isNull(res.body); // non-json response or no schema
+        assert((Object.keys(res.body).length === 0) || (res.body === null)); // non-json response (sets body to empty obj) or no schema
         done();
       });
     });
@@ -60,7 +60,7 @@ describe('/user', function() {
       .end(function(err, res) {
         if (err) return done(err);
 
-        assert.isNull(res.body); // non-json response or no schema
+        assert((Object.keys(res.body).length === 0) || (res.body === null)); // non-json response (sets body to empty obj) or no schema
         done();
       });
     });
@@ -103,7 +103,7 @@ describe('/user', function() {
       .end(function(err, res) {
         if (err) return done(err);
 
-        assert.isNull(res.body); // non-json response or no schema
+        assert((Object.keys(res.body).length === 0) || (res.body === null)); // non-json response (sets body to empty obj) or no schema
         done();
       });
     });
@@ -155,7 +155,7 @@ describe('/user', function() {
       .end(function(err, res) {
         if (err) return done(err);
 
-        assert.isNull(res.body); // non-json response or no schema
+        assert((Object.keys(res.body).length === 0) || (res.body === null)); // non-json response (sets body to empty obj) or no schema
         done();
       });
     });
@@ -174,7 +174,7 @@ describe('/user', function() {
       .end(function(err, res) {
         if (err) return done(err);
 
-        assert.isNull(res.body); // non-json response or no schema
+        assert((Object.keys(res.body).length === 0) || (res.body === null)); // non-json response (sets body to empty obj) or no schema
         done();
       });
     });
@@ -193,7 +193,7 @@ describe('/user', function() {
       .end(function(err, res) {
         if (err) return done(err);
 
-        assert.isNull(res.body); // non-json response or no schema
+        assert((Object.keys(res.body).length === 0) || (res.body === null)); // non-json response (sets body to empty obj) or no schema
         done();
       });
     });
@@ -215,7 +215,7 @@ describe('/user', function() {
       .end(function(err, res) {
         if (err) return done(err);
 
-        assert.isNull(res.body); // non-json response or no schema
+        assert((Object.keys(res.body).length === 0) || (res.body === null)); // non-json response (sets body to empty obj) or no schema
         done();
       });
     });
@@ -270,7 +270,7 @@ describe('/user', function() {
       .end(function(err, res) {
         if (err) return done(err);
 
-        assert.isNull(res.body); // non-json response or no schema
+        assert((Object.keys(res.body).length === 0) || (res.body === null)); // non-json response (sets body to empty obj) or no schema
         done();
       });
     });
@@ -325,7 +325,7 @@ describe('/user', function() {
       .end(function(err, res) {
         if (err) return done(err);
 
-        assert.isNull(res.body); // non-json response or no schema
+        assert((Object.keys(res.body).length === 0) || (res.body === null)); // non-json response (sets body to empty obj) or no schema
         done();
       });
     });
@@ -380,7 +380,7 @@ describe('/user', function() {
       .end(function(err, res) {
         if (err) return done(err);
 
-        assert.isNull(res.body); // non-json response or no schema
+        assert((Object.keys(res.body).length === 0) || (res.body === null)); // non-json response (sets body to empty obj) or no schema
         done();
       });
     });
@@ -396,7 +396,7 @@ describe('/user', function() {
       .end(function(err, res) {
         if (err) return done(err);
 
-        assert.isNull(res.body); // non-json response or no schema
+        assert((Object.keys(res.body).length === 0) || (res.body === null)); // non-json response (sets body to empty obj) or no schema
         done();
       });
     });

--- a/test/minimal/compare/supertest/assert/base-path-test.js
+++ b/test/minimal/compare/supertest/assert/base-path-test.js
@@ -18,7 +18,7 @@ describe('/', function() {
       .end(function(err, res) {
         if (err) return done(err);
 
-        assert.isNull(res.body); // non-json response or no schema
+        assert((Object.keys(res.body).length === 0) || (res.body === null)); // non-json response (sets body to empty obj) or no schema
         done();
       });
     });

--- a/test/robust/compare/request/assert/base-path-test.js
+++ b/test/robust/compare/request/assert/base-path-test.js
@@ -88,7 +88,7 @@ describe('/', function() {
 
         assert.equal(res.statusCode, 200);
 
-        assert.true(validator.validate(body, schema));
+        assert(validator.validate(body, schema), 'Schema validation failed');
         done();
       });
     });
@@ -120,7 +120,7 @@ describe('/', function() {
 
         assert.equal(res.statusCode, 400);
 
-        assert.true(validator.validate(body, schema));
+        assert(validator.validate(body, schema), 'Schema validation failed');
         done();
       });
     });
@@ -164,7 +164,7 @@ describe('/', function() {
 
         assert.equal(res.statusCode, 500);
 
-        assert.true(validator.validate(body, schema));
+        assert(validator.validate(body, schema), 'Schema validation failed');
         done();
       });
     });
@@ -210,7 +210,7 @@ describe('/', function() {
 
         assert.equal(res.statusCode, 200);
 
-        assert.true(validator.validate(body, schema));
+        assert(validator.validate(body, schema), 'Schema validation failed');
         done();
       });
     });
@@ -242,7 +242,7 @@ describe('/', function() {
 
         assert.equal(res.statusCode, 400);
 
-        assert.true(validator.validate(body, schema));
+        assert(validator.validate(body, schema), 'Schema validation failed');
         done();
       });
     });
@@ -274,7 +274,7 @@ describe('/', function() {
 
         assert.equal(res.statusCode, 500);
 
-        assert.true(validator.validate(body, schema));
+        assert(validator.validate(body, schema), 'Schema validation failed');
         done();
       });
     });

--- a/test/robust/compare/supertest/assert/base-path-test.js
+++ b/test/robust/compare/supertest/assert/base-path-test.js
@@ -82,7 +82,7 @@ describe('/', function() {
       .end(function(err, res) {
         if (err) return done(err);
 
-        assert(validator.validate(res.body, schema), 'Schema validation failed');
+        assert(validator.validate(res.body, schema), 'Schema validation failed: ' + JSON.stringify(validator.getLastErrors()));
         done();
       });
     });
@@ -107,7 +107,7 @@ describe('/', function() {
       .end(function(err, res) {
         if (err) return done(err);
 
-        assert(validator.validate(res.body, schema), 'Schema validation failed');
+        assert(validator.validate(res.body, schema), 'Schema validation failed: ' + JSON.stringify(validator.getLastErrors()));
         done();
       });
     });
@@ -144,7 +144,7 @@ describe('/', function() {
       .end(function(err, res) {
         if (err) return done(err);
 
-        assert(validator.validate(res.body, schema), 'Schema validation failed');
+        assert(validator.validate(res.body, schema), 'Schema validation failed: ' + JSON.stringify(validator.getLastErrors()));
         done();
       });
     });
@@ -183,7 +183,7 @@ describe('/', function() {
       .end(function(err, res) {
         if (err) return done(err);
 
-        assert(validator.validate(res.body, schema), 'Schema validation failed');
+        assert(validator.validate(res.body, schema), 'Schema validation failed: ' + JSON.stringify(validator.getLastErrors()));
         done();
       });
     });
@@ -208,7 +208,7 @@ describe('/', function() {
       .end(function(err, res) {
         if (err) return done(err);
 
-        assert(validator.validate(res.body, schema), 'Schema validation failed');
+        assert(validator.validate(res.body, schema), 'Schema validation failed: ' + JSON.stringify(validator.getLastErrors()));
         done();
       });
     });
@@ -233,7 +233,7 @@ describe('/', function() {
       .end(function(err, res) {
         if (err) return done(err);
 
-        assert(validator.validate(res.body, schema), 'Schema validation failed');
+        assert(validator.validate(res.body, schema), 'Schema validation failed: ' + JSON.stringify(validator.getLastErrors()));
         done();
       });
     });

--- a/test/robust/compare/supertest/assert/base-path-test.js
+++ b/test/robust/compare/supertest/assert/base-path-test.js
@@ -82,7 +82,7 @@ describe('/', function() {
       .end(function(err, res) {
         if (err) return done(err);
 
-        assert.true(validator.validate(res.body, schema));
+        assert(validator.validate(res.body, schema));
         done();
       });
     });
@@ -107,7 +107,7 @@ describe('/', function() {
       .end(function(err, res) {
         if (err) return done(err);
 
-        assert.true(validator.validate(res.body, schema));
+        assert(validator.validate(res.body, schema));
         done();
       });
     });
@@ -144,7 +144,7 @@ describe('/', function() {
       .end(function(err, res) {
         if (err) return done(err);
 
-        assert.true(validator.validate(res.body, schema));
+        assert(validator.validate(res.body, schema));
         done();
       });
     });
@@ -183,7 +183,7 @@ describe('/', function() {
       .end(function(err, res) {
         if (err) return done(err);
 
-        assert.true(validator.validate(res.body, schema));
+        assert(validator.validate(res.body, schema));
         done();
       });
     });
@@ -208,7 +208,7 @@ describe('/', function() {
       .end(function(err, res) {
         if (err) return done(err);
 
-        assert.true(validator.validate(res.body, schema));
+        assert(validator.validate(res.body, schema));
         done();
       });
     });
@@ -233,7 +233,7 @@ describe('/', function() {
       .end(function(err, res) {
         if (err) return done(err);
 
-        assert.true(validator.validate(res.body, schema));
+        assert(validator.validate(res.body, schema));
         done();
       });
     });

--- a/test/robust/compare/supertest/assert/base-path-test.js
+++ b/test/robust/compare/supertest/assert/base-path-test.js
@@ -82,7 +82,7 @@ describe('/', function() {
       .end(function(err, res) {
         if (err) return done(err);
 
-        assert(validator.validate(res.body, schema));
+        assert(validator.validate(res.body, schema), 'Schema validation failed');
         done();
       });
     });
@@ -107,7 +107,7 @@ describe('/', function() {
       .end(function(err, res) {
         if (err) return done(err);
 
-        assert(validator.validate(res.body, schema));
+        assert(validator.validate(res.body, schema), 'Schema validation failed');
         done();
       });
     });
@@ -144,7 +144,7 @@ describe('/', function() {
       .end(function(err, res) {
         if (err) return done(err);
 
-        assert(validator.validate(res.body, schema));
+        assert(validator.validate(res.body, schema), 'Schema validation failed');
         done();
       });
     });
@@ -183,7 +183,7 @@ describe('/', function() {
       .end(function(err, res) {
         if (err) return done(err);
 
-        assert(validator.validate(res.body, schema));
+        assert(validator.validate(res.body, schema), 'Schema validation failed');
         done();
       });
     });
@@ -208,7 +208,7 @@ describe('/', function() {
       .end(function(err, res) {
         if (err) return done(err);
 
-        assert(validator.validate(res.body, schema));
+        assert(validator.validate(res.body, schema), 'Schema validation failed');
         done();
       });
     });
@@ -233,7 +233,7 @@ describe('/', function() {
       .end(function(err, res) {
         if (err) return done(err);
 
-        assert(validator.validate(res.body, schema));
+        assert(validator.validate(res.body, schema), 'Schema validation failed');
         done();
       });
     });

--- a/test/robust/compare/supertest/assert/user-test.js
+++ b/test/robust/compare/supertest/assert/user-test.js
@@ -16,7 +16,7 @@ describe('/user', function() {
       .end(function(err, res) {
         if (err) return done(err);
 
-        assert.isNull(res.body); // non-json response or no schema
+        assert((Object.keys(res.body).length === 0) || (res.body === null)); // non-json response (sets body to empty obj) or no schema
         done();
       });
     });
@@ -29,7 +29,7 @@ describe('/user', function() {
       .end(function(err, res) {
         if (err) return done(err);
 
-        assert.isNull(res.body); // non-json response or no schema
+        assert((Object.keys(res.body).length === 0) || (res.body === null)); // non-json response (sets body to empty obj) or no schema
         done();
       });
     });
@@ -42,7 +42,7 @@ describe('/user', function() {
       .end(function(err, res) {
         if (err) return done(err);
 
-        assert.isNull(res.body); // non-json response or no schema
+        assert((Object.keys(res.body).length === 0) || (res.body === null)); // non-json response (sets body to empty obj) or no schema
         done();
       });
     });
@@ -64,7 +64,7 @@ describe('/user', function() {
       .end(function(err, res) {
         if (err) return done(err);
 
-        assert.isNull(res.body); // non-json response or no schema
+        assert((Object.keys(res.body).length === 0) || (res.body === null)); // non-json response (sets body to empty obj) or no schema
         done();
       });
     });
@@ -83,7 +83,7 @@ describe('/user', function() {
       .end(function(err, res) {
         if (err) return done(err);
 
-        assert.isNull(res.body); // non-json response or no schema
+        assert((Object.keys(res.body).length === 0) || (res.body === null)); // non-json response (sets body to empty obj) or no schema
         done();
       });
     });
@@ -102,7 +102,7 @@ describe('/user', function() {
       .end(function(err, res) {
         if (err) return done(err);
 
-        assert.isNull(res.body); // non-json response or no schema
+        assert((Object.keys(res.body).length === 0) || (res.body === null)); // non-json response (sets body to empty obj) or no schema
         done();
       });
     });
@@ -124,7 +124,7 @@ describe('/user', function() {
       .end(function(err, res) {
         if (err) return done(err);
 
-        assert.isNull(res.body); // non-json response or no schema
+        assert((Object.keys(res.body).length === 0) || (res.body === null)); // non-json response (sets body to empty obj) or no schema
         done();
       });
     });
@@ -143,7 +143,7 @@ describe('/user', function() {
       .end(function(err, res) {
         if (err) return done(err);
 
-        assert.isNull(res.body); // non-json response or no schema
+        assert((Object.keys(res.body).length === 0) || (res.body === null)); // non-json response (sets body to empty obj) or no schema
         done();
       });
     });
@@ -162,7 +162,7 @@ describe('/user', function() {
       .end(function(err, res) {
         if (err) return done(err);
 
-        assert.isNull(res.body); // non-json response or no schema
+        assert((Object.keys(res.body).length === 0) || (res.body === null)); // non-json response (sets body to empty obj) or no schema
         done();
       });
     });
@@ -181,7 +181,7 @@ describe('/user', function() {
       .end(function(err, res) {
         if (err) return done(err);
 
-        assert.isNull(res.body); // non-json response or no schema
+        assert((Object.keys(res.body).length === 0) || (res.body === null)); // non-json response (sets body to empty obj) or no schema
         done();
       });
     });
@@ -197,7 +197,7 @@ describe('/user', function() {
       .end(function(err, res) {
         if (err) return done(err);
 
-        assert.isNull(res.body); // non-json response or no schema
+        assert((Object.keys(res.body).length === 0) || (res.body === null)); // non-json response (sets body to empty obj) or no schema
         done();
       });
     });


### PR DESCRIPTION
In generated assert-style checks, `assert.true` was used, which gives error `assert.true is not a function`. This PR changes all assert.true to simply `assert`. 

Also, this adds a simple message to failed schema validation asserts